### PR TITLE
Add player search capability for match invites

### DIFF
--- a/src/TennisMatchApp.jsx
+++ b/src/TennisMatchApp.jsx
@@ -7,6 +7,7 @@ import {
   cancelMatch,
   joinMatch,
   leaveMatch,
+  searchPlayers,
 } from "./services/matches";
 import ProfileManager from "./components/ProfileManager";
 import {
@@ -1399,21 +1400,20 @@ const TennisMatchApp = () => {
       setTimeout(() => setCopiedLink(false), 2000);
     };
 
-    useEffect(() => {
-      if (searchTerm.length >= 2) {
-        apiClient
-          .get(`/players?search=${encodeURIComponent(searchTerm)}`)
-          .then((res) => setPlayers(res.data.players || []))
-          .catch((err) =>
-            displayToast(
-              err.response?.data?.message || "Failed to load players",
-              "error"
-            )
-          );
-      } else {
-        setPlayers([]);
-      }
-    }, [searchTerm]);
+      useEffect(() => {
+        if (searchTerm === "" || searchTerm.length >= 2) {
+          searchPlayers({ search: searchTerm })
+            .then((data) => setPlayers(data.players || []))
+            .catch((err) =>
+              displayToast(
+                err.response?.data?.message || "Failed to load players",
+                "error"
+              )
+            );
+        } else {
+          setPlayers([]);
+        }
+      }, [searchTerm]);
 
     // Keep search input focused after each render when typing
     useEffect(() => {

--- a/src/services/matches.js
+++ b/src/services/matches.js
@@ -45,3 +45,12 @@ export const acceptInvite = async (token) => {
   return data;
 };
 
+export const searchPlayers = async (
+  { search = '', page = 1, perPage = 12 } = {}
+) => {
+  const { data } = await apiClient.get('/matches/players', {
+    params: { search, page, perPage },
+  });
+  return data;
+};
+


### PR DESCRIPTION
## Summary
- expose `/matches/players` endpoint via `searchPlayers` service
- load and search players from API in invite screen

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b977f8cbe0832aa470cc9864ea3cd1