### PR TITLE
feat: add shareable match links

### DIFF
--- a/src/services/invites.js
+++ b/src/services/invites.js
@@ -18,3 +18,8 @@ export const rejectInvite = async (token) => {
   const { data } = await apiClient.post('/invites/reject', { token });
   return data;
 };
+
+export const getInviteByToken = async (token) => {
+  const { data } = await apiClient.get(`/invites/${token}`);
+  return data;
+};


### PR DESCRIPTION
## Summary
- fetch match share links from API and allow copying
- resolve invite tokens in URL to view match details

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bac54026a0832ab31614884f541948