### PR TITLE
Add draft match save and filter functionality

### DIFF
--- a/src/TennisMatchApp.jsx
+++ b/src/TennisMatchApp.jsx
@@ -206,7 +206,7 @@ const TennisMatchApp = () => {
 
     const fetchMatches = useCallback(async () => {
       try {
-        const filter = activeFilter === "draft" ? undefined : activeFilter;
+        const filter = activeFilter === "draft" ? "my" : activeFilter;
         const status = activeFilter === "draft" ? "draft" : undefined;
         const data = await listMatches(filter, {
           status,
@@ -217,7 +217,7 @@ const TennisMatchApp = () => {
       const rawMatches = data.matches || [];
       setMatchCounts(data.counts || {});
       setMatchPagination(data.pagination);
-      const transformed = rawMatches.map((m) => {
+      let transformed = rawMatches.map((m) => {
         const participantCount = (m.participants || []).filter(
           (p) => p.status !== "left"
         ).length;
@@ -255,6 +255,9 @@ const TennisMatchApp = () => {
           spotsAvailable: Math.max(m.player_limit - occupied, 0),
         };
       });
+      if (activeFilter === "draft") {
+        transformed = transformed.filter((m) => m.status === "draft");
+      }
       setMatches(transformed);
     } catch (err) {
       displayToast(
@@ -591,7 +594,7 @@ const TennisMatchApp = () => {
       <div className="bg-white rounded-2xl shadow-sm hover:shadow-2xl transition-all p-6 border border-gray-100 group hover:scale-[1.02]">
         <div className="flex justify-between items-start mb-4">
           <div className="flex flex-wrap items-center gap-2">
-            {match.privacy === "open" && match.status !== "draft" && (
+            {match.privacy === "open" && (
               <span className="px-3 py-1.5 bg-gradient-to-r from-green-50 to-emerald-50 text-green-700 border border-green-200 rounded-full text-xs font-black flex items-center gap-1.5">
                 <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
                 OPEN

--- a/src/TennisMatchApp.jsx
+++ b/src/TennisMatchApp.jsx
@@ -238,7 +238,8 @@ const TennisMatchApp = () => {
         return {
           id: matchId,
           type: isHost ? "hosted" : isJoined ? "joined" : "available",
-          status: m.match_type === "private" ? "closed" : m.status || "open",
+          status: m.status || "upcoming",
+          privacy: m.match_type || "open",
           dateTime: m.start_date_time,
           location: m.location_text,
           latitude: m.latitude,
@@ -590,15 +591,20 @@ const TennisMatchApp = () => {
       <div className="bg-white rounded-2xl shadow-sm hover:shadow-2xl transition-all p-6 border border-gray-100 group hover:scale-[1.02]">
         <div className="flex justify-between items-start mb-4">
           <div className="flex flex-wrap items-center gap-2">
-            {match.status === "open" && (
+            {match.privacy === "open" && match.status !== "draft" && (
               <span className="px-3 py-1.5 bg-gradient-to-r from-green-50 to-emerald-50 text-green-700 border border-green-200 rounded-full text-xs font-black flex items-center gap-1.5">
                 <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
                 OPEN
               </span>
             )}
-            {match.status === "closed" && (
+            {match.privacy === "private" && (
               <span className="px-3 py-1.5 bg-gray-100 text-gray-600 border border-gray-200 rounded-full text-xs font-black">
                 PRIVATE
+              </span>
+            )}
+            {match.status === "draft" && (
+              <span className="px-3 py-1.5 bg-gradient-to-r from-yellow-50 to-amber-50 text-amber-700 border border-amber-200 rounded-full text-xs font-black">
+                DRAFT
               </span>
             )}
             {isHosted && (

--- a/src/TennisMatchApp.jsx
+++ b/src/TennisMatchApp.jsx
@@ -775,6 +775,8 @@ const TennisMatchApp = () => {
       return () => document.removeEventListener("click", handleClickOutside);
     }, [onClose]);
 
+    const match = matches.find((m) => m.id === matchId);
+
     return (
       <div className="match-menu absolute right-0 mt-2 w-52 bg-white rounded-xl shadow-2xl border border-gray-100 z-50 overflow-hidden">
         {type === "host" ? (
@@ -808,6 +810,26 @@ const TennisMatchApp = () => {
             >
               <Bell className="w-4 h-4 text-gray-500" /> Send Reminder
             </button>
+            {match?.status === "draft" && (
+              <button
+                onClick={async () => {
+                  try {
+                    await updateMatch(matchId, { status: "upcoming" });
+                    displayToast("Match published");
+                    onClose();
+                    fetchMatches();
+                  } catch (err) {
+                    displayToast(
+                      err.response?.data?.message || "Failed to publish match",
+                      "error"
+                    );
+                  }
+                }}
+                className="w-full px-4 py-3 text-left text-sm font-bold text-green-700 hover:bg-green-50 flex items-center gap-2 transition-colors"
+              >
+                <Zap className="w-4 h-4 text-green-500" /> Publish Match
+              </button>
+            )}
             <button
               onClick={async () => {
                 try {
@@ -1961,7 +1983,7 @@ const TennisMatchApp = () => {
                         displayToast("No new players selected", "error");
                         return;
                       }
-                      await updateMatch(inviteMatchId, { status: "open" });
+                      await updateMatch(inviteMatchId, { status: "upcoming" });
                       await sendInvites(inviteMatchId, newIds);
 
                       displayToast(

--- a/src/services/matches.js
+++ b/src/services/matches.js
@@ -7,10 +7,11 @@ export const createMatch = async (match) => {
 
 export const listMatches = async (
   filter,
-  { search = '', page = 1, perPage = 10 } = {}
+  { status, search = '', page = 1, perPage = 10 } = {}
 ) => {
   const params = { page, perPage };
   if (filter) params.filter = filter;
+  if (status) params.status = status;
   if (search) params.search = search;
   const { data } = await apiClient.get('/matches', { params });
   return data;


### PR DESCRIPTION
## Summary
- allow API match listing to filter by status
- enable saving new matches as drafts and update them to open when sending invites
- add "Drafts" tab to browse saved matches

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbbc5e0d44832a936b9f3992df043b