### PR TITLE
Connect signup flow to profile API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,40 @@ VITE_GOOGLE_API_KEY=your_key_here
 - `npm run lint` – run ESLint checks
 - `npm run deploy` – build and publish the site to GitHub Pages
 
+## Authentication
+
+Users must sign up or log in to view match data. Guests are prompted to authenticate before any matches are shown.
+
+## API Examples
+
+### Sign Up
+
+```bash
+curl --location 'http://localhost:3000/api/auth/signup' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "email": "Player5@gmail.com",
+    "password": "0000",
+    "user_type":2
+}'
+```
+
+### Update Player Profile
+
+```bash
+curl --location 'http://localhost:3000/api/player/personal_details' \
+--header 'Authorization: token x.x.x' \
+--header 'Content-Type: application/json' \
+--data '{
+   "full_name":"pratik player",
+   "phone":354435,
+   "profile_picture":"asdaffdsadfsf",
+   "date_of_birth":"1999-11-06",
+   "usta_rating":5,
+   "uta_rating":3
+}'
+```
+
 ## Deploying to GitHub Pages
 
 This project can be hosted on GitHub Pages. Run the deploy script to build the site and push the generated files to the `gh-pages` branch:


### PR DESCRIPTION
## Summary
- Call backend signup and profile update APIs during phone verification
- Gate match browsing behind authentication
- Document login requirement in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbdd6d74b4832a9dd7d508f61656b4