### PR TITLE
Remove skill level selection from private group creation

### DIFF
--- a/src/TennisMatchApp.jsx
+++ b/src/TennisMatchApp.jsx
@@ -1421,64 +1421,49 @@ const TennisMatchApp = () => {
             </h2>
 
             <div className="space-y-6">
-              <div>
-                <div className="flex items-center justify-between mb-4">
-                  <label className="text-sm font-black text-gray-700 uppercase tracking-wider">
-                    NTRP Skill Level
-                  </label>
-                  {matchData.type === "open" ? (
+              {matchData.type === "open" && (
+                <div>
+                  <div className="flex items-center justify-between mb-4">
+                    <label className="text-sm font-black text-gray-700 uppercase tracking-wider">
+                      NTRP Skill Level
+                    </label>
                     <span className="px-3 py-1.5 bg-red-100 text-red-700 text-xs rounded-full font-black">
                       REQUIRED
                     </span>
-                  ) : (
-                    <span className="px-3 py-1.5 bg-gray-100 text-gray-600 text-xs rounded-full font-black">
-                      OPTIONAL
-                    </span>
-                  )}
-                </div>
-                <div className="grid grid-cols-3 gap-3">
-                  {[
-                    {
-                      value: "2.5 - Beginner",
-                      label: "2.5",
-                      desc: "Beginner",
-                      color: "from-blue-400 to-blue-500",
-                    },
-                    {
-                      value: "3.0 - Adv. Beginner",
-                      label: "3.0",
-                      desc: "Developing",
-                      color: "from-green-400 to-green-500",
-                    },
-                    {
-                      value: "3.5 - Intermediate",
-                      label: "3.5",
-                      desc: "Intermediate",
-                      color: "from-yellow-400 to-amber-500",
-                    },
-                    {
-                      value: "4.0 - Adv. Intermediate",
-                      label: "4.0",
-                      desc: "Advanced",
-                      color: "from-orange-400 to-orange-500",
-                    },
-                    {
-                      value: "4.5+ - Advanced",
-                      label: "4.5+",
-                      desc: "Expert",
-                      color: "from-red-400 to-red-500",
-                    },
-                    matchData.type === "closed"
-                      ? {
-                          value: "Any Level",
-                          label: "Any",
-                          desc: "All Levels",
-                          color: "from-gray-400 to-gray-500",
-                        }
-                      : null,
-                  ]
-                    .filter(Boolean)
-                    .map((level) => (
+                  </div>
+                  <div className="grid grid-cols-3 gap-3">
+                    {[
+                      {
+                        value: "2.5 - Beginner",
+                        label: "2.5",
+                        desc: "Beginner",
+                        color: "from-blue-400 to-blue-500",
+                      },
+                      {
+                        value: "3.0 - Adv. Beginner",
+                        label: "3.0",
+                        desc: "Developing",
+                        color: "from-green-400 to-green-500",
+                      },
+                      {
+                        value: "3.5 - Intermediate",
+                        label: "3.5",
+                        desc: "Intermediate",
+                        color: "from-yellow-400 to-amber-500",
+                      },
+                      {
+                        value: "4.0 - Adv. Intermediate",
+                        label: "4.0",
+                        desc: "Advanced",
+                        color: "from-orange-400 to-orange-500",
+                      },
+                      {
+                        value: "4.5+ - Advanced",
+                        label: "4.5+",
+                        desc: "Expert",
+                        color: "from-red-400 to-red-500",
+                      },
+                    ].map((level) => (
                       <button
                         key={level.value}
                         onClick={() =>
@@ -1507,18 +1492,12 @@ const TennisMatchApp = () => {
                         </div>
                       </button>
                     ))}
-                </div>
-                {matchData.type === "open" && (
+                  </div>
                   <p className="text-xs font-semibold text-gray-500 mt-3">
                     Helps players find appropriate skill matches
                   </p>
-                )}
-                {matchData.type === "closed" && (
-                  <p className="text-xs font-semibold text-gray-500 mt-3">
-                    Optional - helps balance skill levels
-                  </p>
-                )}
-              </div>
+                </div>
+              )}
 
               <div>
                 <label className="block text-sm font-black text-gray-700 mb-3 uppercase tracking-wider">

--- a/src/TennisMatchApp.jsx
+++ b/src/TennisMatchApp.jsx
@@ -54,6 +54,8 @@ import {
 } from "lucide-react";
 import Autocomplete from "react-google-autocomplete";
 
+const DEFAULT_SKILL_LEVEL = "2.5 - Beginner";
+
 const TennisMatchApp = () => {
   const [currentUser, setCurrentUser] = useState(null);
   const [currentScreen, setCurrentScreen] = useState("browse");
@@ -707,7 +709,7 @@ const TennisMatchApp = () => {
               {match.format}
             </span>
           </div>
-          {getNTRPDisplay(match.skillLevel) && (
+          {match.type === "open" && getNTRPDisplay(match.skillLevel) && (
             <>
               <span className="text-gray-300">•</span>
               <span className="text-sm font-black text-gray-900 bg-gradient-to-r from-amber-50 to-orange-50 px-2.5 py-1 rounded-lg">
@@ -1035,7 +1037,10 @@ const TennisMatchApp = () => {
             latitude: matchData.latitude,
             longitude: matchData.longitude,
             playerCount: matchData.playerCount,
-            skillLevel: matchData.skillLevel,
+            skillLevel:
+              matchData.type === "closed"
+                ? DEFAULT_SKILL_LEVEL
+                : matchData.skillLevel,
             format: matchData.format,
             notes: matchData.notes,
           };
@@ -1119,7 +1124,8 @@ const TennisMatchApp = () => {
                   </div>
                 </div>
 
-                {matchData.skillLevel &&
+                {matchData.type === "open" &&
+                  matchData.skillLevel &&
                   matchData.skillLevel !== "Any Level" && (
                     <div className="flex items-start gap-3">
                       <Trophy className="w-6 h-6 text-gray-400 mt-0.5" />
@@ -1173,7 +1179,10 @@ const TennisMatchApp = () => {
                           latitude: matchData.latitude,
                           longitude: matchData.longitude,
                           playerCount: matchData.playerCount,
-                          skillLevel: matchData.skillLevel,
+                          skillLevel:
+                            matchData.type === "closed"
+                              ? DEFAULT_SKILL_LEVEL
+                              : matchData.skillLevel,
                           format: matchData.format,
                           notes: matchData.notes,
                         };
@@ -1247,7 +1256,12 @@ const TennisMatchApp = () => {
                     <button
                       key={type.id}
                       onClick={() =>
-                        setMatchData((prev) => ({ ...prev, type: type.id }))
+                        setMatchData((prev) => ({
+                          ...prev,
+                          type: type.id,
+                          skillLevel:
+                            type.id === "closed" ? DEFAULT_SKILL_LEVEL : null,
+                        }))
                       }
                       className={`p-6 rounded-2xl border-2 transition-all hover:scale-105 ${
                         matchData.type === type.id


### PR DESCRIPTION
## Summary
- hide NTRP skill level inputs when creating private matches

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bedbd45e38832a984688f1740fd975