### PR TITLE
Add GitHub Pages PR preview workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,16 +6,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: "pages"
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     env:
       VITE_API_URL: ${{ secrets.VITE_API_URL }}
@@ -28,16 +26,10 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: dist
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v4
+          branch: gh-pages
+          folder: dist
+          clean-exclude: pr-preview
+          force: false

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,48 @@
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      VITE_API_URL: ${{ secrets.VITE_API_URL }}
+      VITE_GOOGLE_API_KEY: ${{ secrets.VITE_GOOGLE_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        if: github.event.action != 'closed'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        if: github.event.action != 'closed'
+        run: npm ci
+      - name: Build preview
+        if: github.event.action != 'closed'
+        run: npm run build
+      - name: Ensure dist directory exists for teardown
+        if: github.event.action == 'closed'
+        run: mkdir -p dist
+      - name: Deploy PR preview
+        uses: rossjrw/pr-preview-action@v1.6.2
+        with:
+          source-dir: dist
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm ci
       - name: Build preview
         if: github.event.action != 'closed'
-        run: npm run build
+        run: npm run build -- --base="/ttp-play-dates/pr-preview/pr-${{ github.event.number }}/"
       - name: Ensure dist directory exists for teardown
         if: github.event.action == 'closed'
         run: mkdir -p dist


### PR DESCRIPTION
## Summary
- add a pull request preview workflow that builds the app and publishes preview bundles under pr-preview/
- switch the main deploy workflow to push the production build to the gh-pages branch while keeping PR previews intact

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68c94c59fc94832ab570152f398b1f6f