### PR TITLE
Fix Google autocomplete options for location picker

### DIFF
--- a/src/components/MatchCreatorFlow.jsx
+++ b/src/components/MatchCreatorFlow.jsx
@@ -650,7 +650,10 @@ const MatchCreatorFlow = ({ onCancel, onReturnHome, onMatchCreated, currentUser 
                     longitude: typeof lng === "number" ? lng : prev.longitude,
                   }));
                 }}
-                types={["establishment"]}
+                options={{
+                  types: ["establishment"],
+                  fields: ["formatted_address", "geometry", "name", "place_id"],
+                }}
                 className="w-full pl-12 pr-4 py-4 border border-gray-300 rounded-xl focus:ring-2 focus:ring-green-500 focus:border-transparent"
                 placeholder="e.g., Oceanside Tennis Center"
               />


### PR DESCRIPTION
## Summary
- configure the match creation location autocomplete with supported options so Places venues appear

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cac2d3585483288087b2eae0067365