### PR TITLE
Support sending match invites to phone contacts

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -28,7 +28,15 @@ export const unwrap = (p) =>
     }
     if (!r.ok) {
       const msg = data?.error || r.statusText || "API_ERROR";
-      throw new Error(msg);
+      const error = new Error(msg);
+      error.status = r.status;
+      error.data = data;
+      error.response = {
+        data,
+        status: r.status,
+        statusText: r.statusText,
+      };
+      throw error;
     }
     return data;
   });

--- a/src/services/matches.js
+++ b/src/services/matches.js
@@ -63,11 +63,11 @@ export const removeParticipant = (matchId, playerId) =>
     })
   );
 
-export const sendInvites = (matchId, userIds) =>
+export const sendInvites = (matchId, { playerIds = [], phoneNumbers = [] } = {}) =>
   unwrap(
     api(`/matches/${matchId}/invites`, {
       method: "POST",
-      body: JSON.stringify({ playerIds: userIds }),
+      body: JSON.stringify({ playerIds, phoneNumbers }),
     })
   );
 


### PR DESCRIPTION
## Summary
- allow hosts to add ad-hoc phone contacts alongside existing players when inviting to matches
- send the invites API both player ids and phone numbers with improved error and success handling
- surface phone-based invitees and SMS context in the match detail view while enriching API error propagation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc714254bc832a8918f25f9fa47ba7