### PR TITLE
Redesign invitation page experience

### DIFF
--- a/src/InvitationPage.jsx
+++ b/src/InvitationPage.jsx
@@ -2,6 +2,17 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import {
+  CalendarDays,
+  MapPin,
+  ClipboardList,
+  Users,
+  MessageCircle,
+  Mail,
+  Send,
+  ArrowRight,
+  AlertCircle,
+} from "lucide-react";
+import {
   getInvitePreview,
   beginInviteVerification,
   verifyInviteCode,
@@ -146,206 +157,488 @@ export default function InvitationPage() {
   // Render states
   if (loading)
     return (
-      <>
-        <Header />
-        <Page><p>Loading…</p></Page>
-      </>
+      <InvitationLayout>
+        <StatusCard
+          emoji="⏳"
+          title="Loading invite"
+          message="Hang tight while we get the match details ready."
+        />
+      </InvitationLayout>
     );
   if (!preview)
     return (
-      <>
-        <Header />
-        <Page><Alert>Invite not found.</Alert></Page>
-      </>
+      <InvitationLayout>
+        <StatusCard
+          emoji="😕"
+          title="Invite not found"
+          message="This invite may have been removed or the link is incorrect."
+        />
+      </InvitationLayout>
     );
   if (preview.status === "expired")
     return (
-      <>
-        <Header />
-        <Page><Alert>This invite has expired.</Alert></Page>
-      </>
+      <InvitationLayout>
+        <StatusCard
+          emoji="⌛"
+          title="This invite has expired"
+          message="Ask the host to send a fresh invite so you can still join the match."
+        />
+      </InvitationLayout>
     );
   if (preview.status === "revoked")
     return (
-      <>
-        <Header />
-        <Page><Alert>This invite was revoked.</Alert></Page>
-      </>
+      <InvitationLayout>
+        <StatusCard
+          emoji="🚫"
+          title="Invite no longer available"
+          message="The host revoked this invite. Reach out to them if you think this was a mistake."
+        />
+      </InvitationLayout>
     );
   if (preview.status === "full")
     return (
-      <>
-        <Header />
-        <Page><Alert>This match is full.</Alert></Page>
-      </>
+      <InvitationLayout>
+        <StatusCard
+          emoji="🎉"
+          title="This match is full"
+          message="All spots have been claimed, but you can ask the host to open up another session."
+        />
+      </InvitationLayout>
     );
 
-  return (
-    <>
-      <Header />
-      <Page>
-      <h1 className="text-xl font-bold mb-3">Private match invite</h1>
+  const match = preview.match || {};
+  const startDate = match.start_date_time
+    ? new Date(match.start_date_time)
+    : null;
+  const formattedDate = startDate ? formatInviteDate(startDate) : "";
+  const formattedTime = startDate ? formatInviteTime(startDate) : "";
+  const locationLabel = match.location_text || preview?.location_text || "";
+  const skill = formatSkillRange(
+    match.skill_level_min,
+    match.skill_level_max,
+  );
+  const matchType = [
+    match.match_format,
+    skill ? `${skill} Level` : "",
+  ]
+    .filter(Boolean)
+    .join(" • ");
+  const matchHeading = match.match_format
+    ? `${match.match_format} Match`
+    : "Private Match";
 
-      {preview.match && (
-        <div className="mb-4 space-y-1">
-          <div className="font-semibold">{preview.match.match_format} match</div>
-          <div>
-            {new Date(preview.match.start_date_time).toLocaleString()}
-          </div>
-          <div>Host: {preview.inviter?.full_name}</div>
-          {preview.match.location_text && (
-            <div>Location: {preview.match.location_text}</div>
-          )}
-        </div>
+  const participants = getActiveParticipants(match, preview);
+  const playerLimit =
+    asNumber(match.player_limit) ?? asNumber(match.playerLimit);
+  const occupancyFromMatch =
+    asNumber(match.occupied) ??
+    asNumber(match.current_players) ??
+    asNumber(match.currentPlayers);
+  const avatarPlayers =
+    participants.length > 0
+      ? participants
+      : preview?.inviter
+        ? [{ profile: { full_name: preview.inviter.full_name } }]
+        : [];
+  const effectivePlayers =
+    occupancyFromMatch ?? (participants.length ? participants.length : null);
+  const occupancyLabel = playerLimit
+    ? `${effectivePlayers ?? avatarPlayers.length}/${playerLimit}`
+    : effectivePlayers ?? avatarPlayers.length
+    ? `${effectivePlayers ?? avatarPlayers.length}`
+    : null;
+
+  const inviterName = (preview?.inviter?.full_name || "").trim();
+  const inviterFirstName = inviterName.split(" ").filter(Boolean)[0] || "";
+  const inviterInitials = getInitials(inviterName || "Matchplay");
+
+  const availableChannels = preview?.availableChannels || [];
+  const maskedIdentifier = preview?.maskedIdentifier;
+  const activeChannel = lastChannel || selectedChannel;
+  const activeChannelMeta = getChannelMeta(activeChannel);
+
+  const infoItems = [];
+  if (startDate) {
+    infoItems.push({
+      key: "datetime",
+      icon: CalendarDays,
+      accent: "bg-rose-100 text-rose-600",
+      label: "Date & Time",
+      value: `${formattedDate}${formattedTime ? `, ${formattedTime}` : ""}`,
+    });
+  }
+  if (locationLabel) {
+    infoItems.push({
+      key: "location",
+      icon: MapPin,
+      accent: "bg-sky-100 text-sky-600",
+      label: "Location",
+      value: locationLabel,
+    });
+  }
+  if (matchType) {
+    infoItems.push({
+      key: "matchType",
+      icon: ClipboardList,
+      accent: "bg-purple-100 text-purple-600",
+      label: "Match Type",
+      value: matchType,
+    });
+  }
+
+  const channelPicker = showPicker ? (
+    <div className="space-y-4 rounded-2xl border border-amber-200 bg-amber-50/80 p-5 shadow-inner backdrop-blur">
+      <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-amber-800/80">
+        <MessageCircle className="h-4 w-4" />
+        Choose where to receive your code
+      </div>
+      <div className="space-y-3">
+        {availableChannels.map((ch) => {
+          const meta = getChannelMeta(ch);
+          const ChannelIcon = meta.icon;
+          return (
+            <label
+              key={ch}
+              className={`flex items-center gap-3 rounded-2xl border px-3 py-3 transition-all ${
+                selectedChannel === ch
+                  ? "border-amber-400 bg-white shadow-sm shadow-amber-200/50"
+                  : "border-transparent bg-white/70 hover:border-amber-200"
+              }`}
+            >
+              <input
+                type="radio"
+                name="channel"
+                value={ch}
+                checked={selectedChannel === ch}
+                onChange={() => setSelectedChannel(ch)}
+                className="h-4 w-4 text-amber-600 focus:ring-amber-500"
+              />
+              <div
+                className={`flex h-11 w-11 items-center justify-center rounded-2xl ${meta.accent}`}
+              >
+                <ChannelIcon className="h-5 w-5" />
+              </div>
+              <div className="flex-1">
+                <p className="text-sm font-semibold text-amber-900">
+                  {meta.label}
+                </p>
+                {maskedIdentifier && (
+                  <p className="text-xs text-amber-700/80">
+                    Send to {maskedIdentifier}
+                  </p>
+                )}
+              </div>
+            </label>
+          );
+        })}
+      </div>
+      {preview?.identifierRequired && (
+        <label className="block text-sm font-semibold text-amber-900/90">
+          <span className="mb-1 block text-xs uppercase tracking-wide text-amber-700/80">
+            Enter your {prettyRequirement(preview?.requires)}
+          </span>
+          <input
+            className="w-full rounded-xl border border-amber-200 bg-white/90 px-3 py-2 text-amber-900 placeholder:text-amber-400 focus:border-amber-400 focus:outline-none focus:ring focus:ring-amber-200"
+            value={identifier}
+            onChange={(e) => setIdentifier(e.target.value)}
+            placeholder={placeholderFor(preview?.requires)}
+          />
+        </label>
       )}
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <button
+          onClick={begin}
+          className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-amber-500 to-orange-500 px-4 py-2.5 font-semibold text-white shadow-lg shadow-amber-200 transition-transform hover:scale-[1.01]"
+        >
+          Send access code
+        </button>
+        <button
+          onClick={() => setShowPicker(false)}
+          className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-amber-200 bg-white/70 px-4 py-2.5 font-semibold text-amber-700 transition-colors hover:bg-white"
+        >
+          Cancel
+        </button>
+      </div>
+      {error && <ErrorText>{error}</ErrorText>}
+    </div>
+  ) : null;
 
-      {phase === "preview" && (
-        <div className="grid gap-3">
-          <Primary
-            onClick={() => {
-              const channels = preview?.availableChannels || [];
-              if (channels.length > 1 || preview?.identifierRequired) {
-                setShowPicker((v) => !v);
-              } else {
-                // If there's only one channel and no identifier required, send immediately
-                setShowPicker(false);
-                setSelectedChannel(channels[0] || selectedChannel);
-                begin();
-              }
-            }}
-          >
-            Join match
-          </Primary>
+  const secondsUntilResend = resendAt
+    ? Math.max(
+        0,
+        Math.ceil((new Date(resendAt).getTime() - now) / 1000),
+      )
+    : 0;
 
-          {showPicker && (
-            <div className="p-3 border rounded bg-gray-50 grid gap-3">
-              <div className="font-medium">Choose where to receive your code</div>
-              <div className="grid gap-2">
-                {(preview?.availableChannels || []).map((ch) => (
-                  <label key={ch} className="flex items-center gap-2">
-                    <input
-                      type="radio"
-                      name="channel"
-                      value={ch}
-                      checked={selectedChannel === ch}
-                      onChange={() => setSelectedChannel(ch)}
-                    />
-                    <span className="capitalize">{ch}</span>
-                    {preview?.maskedIdentifier && (
-                      <span className="text-gray-500 text-sm">
-                        to {preview.maskedIdentifier}
-                      </span>
-                    )}
-                  </label>
-                ))}
+  const otpSection = (
+    <div className="space-y-5 rounded-[28px] border border-slate-100 bg-white/95 p-6 shadow-xl">
+      <div className="flex items-start gap-3">
+        <div
+          className={`flex h-12 w-12 items-center justify-center rounded-2xl ${activeChannelMeta.accent}`}
+        >
+          <activeChannelMeta.icon className="h-5 w-5" />
+        </div>
+        <div className="flex-1 space-y-1">
+          <p className="text-sm font-semibold text-slate-900">
+            Check your {activeChannelMeta.label.toLowerCase()}
+          </p>
+          <p className="text-sm text-slate-500">
+            We sent a six-digit code
+            {maskedIdentifier ? ` to ${maskedIdentifier}` : ""}. Enter it
+            below to join the match.
+          </p>
+        </div>
+      </div>
+      <label className="block">
+        <span className="sr-only">Verification code</span>
+        <input
+          className="w-full rounded-2xl border border-slate-200 bg-white px-6 py-4 text-center text-2xl font-semibold tracking-[0.65em] text-slate-900 outline-none focus:border-emerald-500 focus:ring-4 focus:ring-emerald-200"
+          inputMode="numeric"
+          maxLength={6}
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          placeholder="••••••"
+        />
+      </label>
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <PrimaryButton
+          onClick={verify}
+          className="w-full sm:w-auto"
+        >
+          Verify &amp; Join
+        </PrimaryButton>
+        <button
+          onClick={resend}
+          disabled={!canResend}
+          className="inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-slate-200 bg-white px-5 py-3 text-sm font-semibold text-slate-600 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-white sm:w-auto"
+          aria-disabled={!canResend}
+        >
+          {canResend ? "Resend code" : `Resend in ${secondsUntilResend}s`}
+        </button>
+        <button
+          onClick={() => {
+            setPhase("preview");
+            setShowPicker(true);
+            setError("");
+          }}
+          className="inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-transparent bg-slate-100 px-5 py-3 text-sm font-semibold text-slate-600 transition-colors hover:bg-slate-200 sm:w-auto"
+        >
+          Change channel
+        </button>
+      </div>
+      {error && <ErrorText>{error}</ErrorText>}
+    </div>
+  );
+
+  const avatarPalette = [
+    "bg-emerald-500",
+    "bg-sky-500",
+    "bg-indigo-500",
+    "bg-purple-500",
+    "bg-amber-500",
+  ];
+  const extraPlayers =
+    avatarPlayers.length > 4 ? avatarPlayers.length - 4 : 0;
+
+  return (
+    <InvitationLayout>
+      <div className="w-full max-w-xl">
+        <div className="overflow-hidden rounded-[32px] border border-white/20 bg-white/10 shadow-[0_24px_60px_-15px_rgba(24,24,27,0.45)] backdrop-blur">
+          <div className="bg-gradient-to-br from-[#fef08a] via-[#fbbf24] to-[#f97316] px-8 pt-8 pb-24 text-center text-amber-900">
+            <div className="flex justify-center">
+              <div className="flex items-center gap-2 rounded-full bg-white/35 px-4 py-1.5 text-sm font-semibold uppercase tracking-wide text-amber-900 shadow-sm">
+                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-white text-xl text-amber-500 shadow-inner">
+                  🎾
+                </div>
+                Matchplay
               </div>
-
-              {preview?.identifierRequired && (
-                <label className="grid gap-1">
-                  <span className="text-sm text-gray-700">
-                    Enter your {prettyRequirement(preview?.requires)}
-                  </span>
-                  <input
-                    className="w-full p-2 border rounded"
-                    value={identifier}
-                    onChange={(e) => setIdentifier(e.target.value)}
-                    placeholder={placeholderFor(preview?.requires)}
-                  />
-                </label>
-              )}
-
-              <div className="flex gap-2">
-                <button
-                  onClick={begin}
-                  className="px-3 py-2 rounded bg-black text-white"
-                >
-                  Send code
-                </button>
-                <button
-                  onClick={() => setShowPicker(false)}
-                  className="px-3 py-2 border rounded"
-                >
-                  Cancel
-                </button>
-              </div>
-
-              {error && <ErrorText>{error}</ErrorText>}
             </div>
-          )}
-
-          {!showPicker && error && <ErrorText>{error}</ErrorText>}
-        </div>
-      )}
-
-      {phase === "otp" && (
-        <div className="grid gap-3">
-          <div className="text-sm text-gray-600">
-            Code sent via {lastChannel || selectedChannel} {preview?.maskedIdentifier ? `to ${preview.maskedIdentifier}` : ""}
+            <div className="mt-6 flex flex-col items-center gap-4">
+              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white text-2xl font-black text-amber-500 shadow-lg shadow-amber-200/70">
+                {inviterInitials}
+              </div>
+              <div className="space-y-1">
+                <p className="text-2xl font-bold">
+                  {inviterFirstName
+                    ? `${inviterFirstName} invited you!`
+                    : "You're invited!"}
+                </p>
+                <p className="text-sm text-amber-800/80">
+                  You're invited to play tennis on Matchplay.
+                </p>
+              </div>
+            </div>
           </div>
-          <label className="grid gap-1">
-            <span>Enter 6-digit code</span>
-            <input
-              className="w-full p-2 border rounded tracking-widest"
-              inputMode="numeric"
-              maxLength={6}
-              value={code}
-              onChange={(e) => setCode(e.target.value)}
-            />
-          </label>
-          <div className="flex items-center gap-3">
-            <Primary onClick={verify}>Verify and join</Primary>
-            <button
-              onClick={resend}
-              disabled={!canResend}
-              className="px-3 py-2 border rounded disabled:opacity-50"
-              aria-disabled={!canResend}
-            >
-              {canResend
-                ? "Resend code"
-                : `Resend in ${Math.max(
-                    0,
-                    Math.ceil((new Date(resendAt).getTime() - now) / 1000)
-                  )}s`}
-            </button>
-            <button
-              onClick={() => {
-                setPhase("preview");
-                setShowPicker(true);
-                setError("");
-              }}
-              className="px-3 py-2 border rounded"
-            >
-              Change channel
-            </button>
+          <div className="relative -mt-16 px-6 pb-8">
+            <div className="rounded-[28px] border border-white/70 bg-white/95 p-6 shadow-xl shadow-slate-900/5 backdrop-blur">
+              <div className="space-y-1 text-center">
+                <h2 className="text-xl font-semibold text-slate-900">
+                  {matchHeading}
+                </h2>
+                <p className="text-sm text-slate-500">
+                  {inviterFirstName
+                    ? `Hosted by ${inviterFirstName}`
+                    : "Hosted on Matchplay"}
+                </p>
+              </div>
+              <div className="mt-5 grid gap-3">
+                {infoItems.length ? (
+                  infoItems.map((item) => {
+                    const ItemIcon = item.icon;
+                    return (
+                      <div
+                        key={item.key}
+                        className="flex items-center gap-3 rounded-2xl border border-slate-100 bg-white/90 px-4 py-3 shadow-sm"
+                      >
+                        <div
+                          className={`flex h-12 w-12 items-center justify-center rounded-2xl ${item.accent}`}
+                        >
+                          <ItemIcon className="h-5 w-5" />
+                        </div>
+                        <div className="flex-1">
+                          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                            {item.label}
+                          </p>
+                          <p className="text-sm font-medium text-slate-900">
+                            {item.value}
+                          </p>
+                        </div>
+                      </div>
+                    );
+                  })
+                ) : (
+                  <div className="rounded-2xl border border-dashed border-slate-200 bg-white/80 px-4 py-3 text-center text-sm text-slate-500">
+                    Match details will appear here once the host finalizes them.
+                  </div>
+                )}
+              </div>
+              <div className="mt-5 rounded-2xl border border-slate-100 bg-slate-50/80 p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                      <Users className="h-4 w-4 text-slate-400" />
+                      Current players{occupancyLabel ? ` (${occupancyLabel})` : ""}
+                    </p>
+                    <p className="mt-1 text-sm text-slate-600">
+                      {avatarPlayers.length
+                        ? "Who's already in the game"
+                        : "Be the first to lock in a spot."}
+                    </p>
+                  </div>
+                  <div className="flex items-center -space-x-3">
+                    {avatarPlayers.length ? (
+                      avatarPlayers.slice(0, 4).map((player, index) => {
+                        const name = participantDisplayName(player) || "Player";
+                        const initials = getInitials(name) || "P";
+                        const color =
+                          avatarPalette[index % avatarPalette.length];
+                        const key =
+                          player?.player_id ||
+                          player?.id ||
+                          player?.invitee_id ||
+                          `${name}-${index}`;
+                        return (
+                          <div
+                            key={key}
+                            title={name}
+                            className={`flex h-10 w-10 items-center justify-center rounded-full border-2 border-white text-sm font-semibold text-white shadow ${color}`}
+                          >
+                            {initials}
+                          </div>
+                        );
+                      })
+                    ) : (
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full border-2 border-dashed border-slate-300 text-sm font-semibold text-slate-400">
+                        +
+                      </div>
+                    )}
+                    {extraPlayers > 0 && (
+                      <div className="flex h-10 w-10 items-center justify-center rounded-full border-2 border-white bg-slate-900/80 text-sm font-semibold text-white shadow">
+                        +{extraPlayers}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="mt-6 space-y-4">
+              {phase === "preview" ? (
+                <>
+                  <PrimaryButton
+                    onClick={() => {
+                      const channels = preview?.availableChannels || [];
+                      if (channels.length > 1 || preview?.identifierRequired) {
+                        setShowPicker((v) => !v);
+                      } else {
+                        setShowPicker(false);
+                        setSelectedChannel(channels[0] || selectedChannel);
+                        begin();
+                      }
+                    }}
+                  >
+                    Join Match &amp; Play
+                    <ArrowRight className="h-4 w-4" />
+                  </PrimaryButton>
+                  {channelPicker}
+                  {!showPicker && error && <ErrorText>{error}</ErrorText>}
+                </>
+              ) : (
+                otpSection
+              )}
+            </div>
           </div>
-          {error && <ErrorText>{error}</ErrorText>}
         </div>
-      )}
-      </Page>
-    </>
+      </div>
+    </InvitationLayout>
   );
 }
 
-/** Lightweight primitives (keeps your Tailwind setup) */
-function Page({ children }) {
+function InvitationLayout({ children }) {
   return (
-    <main className="max-w-xl mx-auto p-4">
-      {children}
-    </main>
+    <div className="min-h-screen bg-gradient-to-br from-[#4c1d95] via-[#4338ca] to-[#2563eb]">
+      <div className="flex min-h-screen flex-col">
+        <Header />
+        <main className="flex flex-1 items-center justify-center px-4 py-10">
+          {children}
+        </main>
+      </div>
+    </div>
   );
 }
-function Primary({ onClick, children }) {
+
+function PrimaryButton({ onClick, children, className = "", disabled }) {
   return (
-    <button onClick={onClick} className="px-4 py-2 rounded bg-black text-white">
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-emerald-400 via-emerald-500 to-teal-500 px-6 py-3 text-base font-semibold text-white shadow-xl shadow-emerald-500/30 transition-transform hover:scale-[1.01] focus:outline-none focus:ring-4 focus:ring-emerald-200 focus:ring-offset-2 focus:ring-offset-white disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:scale-100 ${className}`}
+    >
       {children}
     </button>
   );
 }
+
 function ErrorText({ children }) {
-  return <p className="text-red-600">{children}</p>;
+  return (
+    <p className="flex items-center gap-2 text-sm font-medium text-red-600">
+      <AlertCircle className="h-4 w-4" />
+      <span>{children}</span>
+    </p>
+  );
 }
-function Alert({ children }) {
-  return <div className="p-3 rounded bg-gray-100 border">{children}</div>;
+
+function StatusCard({ emoji, title, message }) {
+  return (
+    <div className="w-full max-w-xl">
+      <div className="space-y-4 rounded-[32px] border border-white/40 bg-white/85 px-8 py-10 text-center shadow-[0_24px_60px_-15px_rgba(24,24,27,0.45)] backdrop-blur">
+        <div className="text-4xl" aria-hidden="true">
+          {emoji}
+        </div>
+        <h2 className="text-2xl font-semibold text-slate-900">{title}</h2>
+        <p className="text-sm text-slate-600">{message}</p>
+      </div>
+    </div>
+  );
 }
 
 // Helpers
@@ -379,4 +672,97 @@ function placeholderFor(req) {
   if (req === "phone") return "+1 555 555 5555";
   if (req === "email") return "you@example.com";
   return "Enter identifier";
+}
+
+function formatInviteDate(date) {
+  return date.toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatInviteTime(date) {
+  return date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatSkillRange(min, max) {
+  const minNum = Number(min);
+  const maxNum = Number(max);
+  const hasMin = Number.isFinite(minNum);
+  const hasMax = Number.isFinite(maxNum);
+  if (hasMin && hasMax) {
+    return `${minNum} - ${maxNum}`;
+  }
+  if (hasMin) return `${minNum}+`;
+  if (hasMax) return `Up to ${maxNum}`;
+  return "";
+}
+
+function getInitials(name) {
+  const clean = (name || "").trim();
+  if (!clean) return "";
+  return clean
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase();
+}
+
+function asNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function getActiveParticipants(match, preview) {
+  const fromMatch = Array.isArray(match?.participants)
+    ? match.participants
+    : [];
+  const fromPreview = Array.isArray(preview?.participants)
+    ? preview.participants
+    : [];
+  const source = fromMatch.length ? fromMatch : fromPreview;
+  return source.filter((p) => p && p.status !== "left");
+}
+
+function participantDisplayName(participant) {
+  if (!participant) return "";
+  return (
+    participant.profile?.full_name ||
+    participant.full_name ||
+    participant.profile?.name ||
+    (participant.player_id ? `Player ${participant.player_id}` : "") ||
+    (participant.invitee_id ? `Invitee ${participant.invitee_id}` : "")
+  );
+}
+
+const CHANNEL_META = {
+  sms: {
+    label: "Text message",
+    accent: "bg-emerald-100 text-emerald-600",
+    icon: MessageCircle,
+  },
+  email: {
+    label: "Email",
+    accent: "bg-sky-100 text-sky-600",
+    icon: Mail,
+  },
+  whatsapp: {
+    label: "WhatsApp",
+    accent: "bg-emerald-100 text-emerald-600",
+    icon: MessageCircle,
+  },
+};
+
+function getChannelMeta(channel) {
+  return CHANNEL_META[channel] || {
+    label: "Message",
+    accent: "bg-slate-100 text-slate-600",
+    icon: Send,
+  };
 }

--- a/src/components/InviteScreen.jsx
+++ b/src/components/InviteScreen.jsx
@@ -18,7 +18,6 @@ import {
   updateMatch,
   sendInvites,
 } from "../services/matches";
-import { formatPhoneDisplay, normalizePhoneValue } from "../services/phone";
 
 const InviteScreen = ({
   matchId,
@@ -47,28 +46,10 @@ const InviteScreen = ({
   const [hostId, setHostId] = useState(null);
 
   // Local state for manual phone invites (isolated from search input)
-  const [localContactName, setLocalContactName] = useState("");
-  const [localContactPhone, setLocalContactPhone] = useState("");
-  const [localContactError, setLocalContactError] = useState("");
-
   const totalSelectedInvitees = useMemo(
     () => selectedPlayers.size,
     [selectedPlayers]
   );
-
-  const addManualContact = () => {
-    setLocalContactError("");
-    const normalized = normalizePhoneValue(localContactPhone);
-    if (!normalized) {
-      setLocalContactError(
-        "Enter a valid phone number with country code or 10 digits."
-      );
-      return;
-    }
-    // For now, manual phone invites are not persisted in this screen.
-    // Could be extended to push SMS-only invites as in create flow.
-    setLocalContactError("Manual phone invites not enabled on this screen");
-  };
 
   const copyLink = () => {
     if (!shareLink) return;
@@ -101,7 +82,7 @@ const InviteScreen = ({
         if (!alive) return;
         setParticipants((data.participants || []).filter((p) => p.status !== "left"));
         setHostId(data.match?.host_id ?? null);
-      } catch (error) {
+      } catch {
         if (!alive) return;
         setParticipants([]);
         setParticipantsError("Failed to load participants");

--- a/src/services/invites.js
+++ b/src/services/invites.js
@@ -21,6 +21,14 @@ export const verifyInviteCode = (token, code) =>
     })
   );
 
+export const claimInvite = (token, payload) =>
+  unwrap(
+    api(`/invites/${token}/claim`, {
+      method: "POST",
+      body: JSON.stringify(payload || {}),
+    })
+  );
+
 export const listInvites = ({ status, page, perPage } = {}) => {
   const params = new URLSearchParams();
   if (status) params.set("status", status);


### PR DESCRIPTION
## Summary
- redesign the invitation landing page with a branded hero, match summary card, and refined join flow
- refresh OTP, channel picker, and status states to align with the new visual direction
- remove unused manual contact helpers from InviteScreen to satisfy lint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3ea955d3c832a992154ec3a762065