### PR TITLE
Handle invite magic code auto verification

### DIFF
--- a/src/InvitationPage.jsx
+++ b/src/InvitationPage.jsx
@@ -64,9 +64,11 @@ export default function InvitationPage() {
     return now >= new Date(resendAt).getTime();
   }, [resendAt, now]);
 
-  const inviteeRequiresAccountClaim = Boolean(
-    preview?.invitee && !preview?.invitee?.user_id,
-  );
+  const inviteeEmail = preview?.invitee?.email || "";
+  const inviteeRequiresAccountClaim = useMemo(() => {
+    if (!inviteeEmail) return false;
+    return inviteeEmail.toLowerCase().endsWith("@ttpplaydates.com");
+  }, [inviteeEmail]);
 
   // Load minimal invite preview
   useEffect(() => {


### PR DESCRIPTION
## Summary
- parse invite magic login codes from the invite URL and attempt verification automatically for returning players
- persist the returned session and follow any redirect on success, otherwise surface friendly errors and reveal the OTP flow
- reset the OTP input when resending codes and memoize session persistence logic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d56f492afc832aa75ceb79c0ede9a1