### PR TITLE
Filter expired invites from pending lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "node --test",
     "preview": "vite preview",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"

--- a/src/TennisMatchApp.jsx
+++ b/src/TennisMatchApp.jsx
@@ -22,6 +22,7 @@ import {
   rejectInvite,
 } from "./services/invites";
 import { login, signup, updatePersonalDetails, forgotPassword } from "./services/auth";
+import { filterActiveInvites } from "./services/inviteFilters";
 import {
   Calendar,
   MapPin,
@@ -288,7 +289,7 @@ const TennisMatchApp = () => {
       setInvitesLoading(true);
       const data = await listInvites({ status: "pending", perPage: 50 });
       const invitesArray = Array.isArray(data?.invites) ? data.invites : data || [];
-      setPendingInvites(invitesArray);
+      setPendingInvites(filterActiveInvites(invitesArray));
       setInvitesError("");
     } catch (err) {
       console.error("Failed to load invites", err);

--- a/src/components/InvitesList.jsx
+++ b/src/components/InvitesList.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { listInvites, acceptInvite, rejectInvite } from '../services/invites';
+import { filterActiveInvites } from '../services/inviteFilters';
 import {
   Check,
   X,
@@ -27,7 +28,8 @@ const InvitesList = ({ onInviteResponse }) => {
       try {
         setLoading(true);
         const data = await listInvites();
-        setInvites(data.invites || data || []);
+        const invitesArray = Array.isArray(data?.invites) ? data.invites : data || [];
+        setInvites(filterActiveInvites(invitesArray));
       } catch (err) {
         console.error(err);
         setError('Failed to load invites');

--- a/src/services/inviteFilters.js
+++ b/src/services/inviteFilters.js
@@ -1,0 +1,11 @@
+export const filterActiveInvites = (invites) => {
+  if (!Array.isArray(invites)) return [];
+  const now = Date.now();
+  return invites.filter((invite) => {
+    const referenceDate = invite?.expires_at || invite?.match?.start_date_time;
+    if (!referenceDate) return true;
+    const parsed = new Date(referenceDate);
+    if (Number.isNaN(parsed.getTime())) return true;
+    return parsed.getTime() >= now;
+  });
+};

--- a/tests/inviteFilters.test.js
+++ b/tests/inviteFilters.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { filterActiveInvites } from '../src/services/inviteFilters.js';
+
+const minutesFromNow = (minutes) =>
+  new Date(Date.now() + minutes * 60 * 1000).toISOString();
+
+test('filters out invites whose match start time is in the past', () => {
+  const invites = [
+    { token: 'future', match: { start_date_time: minutesFromNow(60) } },
+    { token: 'past', match: { start_date_time: minutesFromNow(-60) } },
+  ];
+
+  const result = filterActiveInvites(invites);
+
+  assert.deepEqual(
+    result.map((invite) => invite.token),
+    ['future'],
+    'only future match invites should remain',
+  );
+});
+
+test('uses invite expiration when provided', () => {
+  const invites = [
+    { token: 'future', expires_at: minutesFromNow(120) },
+    { token: 'expired', expires_at: minutesFromNow(-5), match: { start_date_time: minutesFromNow(120) } },
+  ];
+
+  const result = filterActiveInvites(invites);
+
+  assert.deepEqual(
+    result.map((invite) => invite.token),
+    ['future'],
+    'invites past their expiration should be removed even if match is upcoming',
+  );
+});
+
+test('keeps invites with missing or invalid dates', () => {
+  const invites = [
+    { token: 'missing-dates' },
+    { token: 'invalid-date', match: { start_date_time: 'not-a-date' } },
+  ];
+
+  const result = filterActiveInvites(invites);
+
+  assert.deepEqual(
+    result.map((invite) => invite.token),
+    ['missing-dates', 'invalid-date'],
+    'invites without usable timestamps should remain',
+  );
+});


### PR DESCRIPTION
## Summary
- filter pending invites in TennisMatchApp so expired entries never reach state
- reuse the same filtering in InvitesList so the review view hides expired invites
- add invite filtering unit tests covering start times and expirations using the shared helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5b00b8658832894930fe7565550f8