### PR TITLE
Auto-detect user location on initial entry

### DIFF
--- a/src/TennisMatchApp.jsx
+++ b/src/TennisMatchApp.jsx
@@ -229,6 +229,7 @@ const TennisMatchApp = () => {
 
   const totalSelectedInvitees = selectedPlayers.size + manualContacts.size;
   const lastInviteLoadRef = useRef(null);
+  const autoDetectAttemptedRef = useRef(false);
 
   useEffect(() => {
     setMatchPage(1);
@@ -342,6 +343,19 @@ const TennisMatchApp = () => {
       },
     );
   }, []);
+
+  useEffect(() => {
+    if (autoDetectAttemptedRef.current) return;
+    if (!currentUser) return;
+
+    if (locationFilter?.lat && locationFilter?.lng) {
+      autoDetectAttemptedRef.current = true;
+      return;
+    }
+
+    autoDetectAttemptedRef.current = true;
+    detectCurrentLocation();
+  }, [currentUser, detectCurrentLocation, locationFilter]);
 
   // Match loading helpers
   const fetchMatches = useCallback(async () => {

--- a/src/services/matches.js
+++ b/src/services/matches.js
@@ -18,12 +18,35 @@ export const createMatch = (match) =>
 
 export const listMatches = (
   filter,
-  { status, search = "", page = 1, perPage = 10 } = {}
+  {
+    status,
+    search = "",
+    page = 1,
+    perPage = 10,
+    latitude,
+    longitude,
+    distance,
+    radius,
+  } = {},
 ) => {
   const params = { page, perPage };
   if (filter) params.filter = filter;
   if (status) params.status = status;
   if (search) params.search = search;
+  const addNumericParam = (key, value) => {
+    if (value === undefined || value === null) return;
+    const numeric =
+      typeof value === "string" ? Number.parseFloat(value) : value;
+    if (Number.isFinite(numeric)) {
+      params[key] = numeric;
+    }
+  };
+  addNumericParam("latitude", latitude);
+  addNumericParam("longitude", longitude);
+  addNumericParam("distance", distance);
+  if (!Object.prototype.hasOwnProperty.call(params, "distance")) {
+    addNumericParam("radius", radius);
+  }
   return unwrap(api(`/matches${qs(params)}`));
 };
 


### PR DESCRIPTION
## Summary
- trigger geolocation detection the first time a logged-in user lands without a saved location filter
- guard against repeated prompts by tracking that an auto-detect attempt has already happened

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5dc4277448328b71118d6532fbd93