### PR TITLE
Fix quick action date labels to use local timezone

### DIFF
--- a/src/components/MatchCreatorFlow.jsx
+++ b/src/components/MatchCreatorFlow.jsx
@@ -35,13 +35,26 @@ import {
 const HOURS_IN_MS = 60 * 60 * 1000;
 const MAX_PRIVATE_INVITES = 12;
 
+const formatLocalDateValue = (date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const formatLocalTimeValue = (date) => {
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${hours}:${minutes}`;
+};
+
 const defaultDateInfo = () => {
   const base = new Date();
   base.setDate(base.getDate() + 1);
   base.setHours(18, 0, 0, 0);
   return {
-    date: base.toISOString().slice(0, 10),
-    time: base.toISOString().slice(11, 16),
+    date: formatLocalDateValue(base),
+    time: formatLocalTimeValue(base),
   };
 };
 
@@ -194,7 +207,7 @@ const quickDateOptions = () => {
     return {
       value: `offset-${offset}`,
       label: d.toLocaleDateString("en-US", { weekday: "long" }),
-      date: d.toISOString().slice(0, 10),
+      date: formatLocalDateValue(d),
     };
   };
   return [makeOption(0), makeOption(1), makeOption(2), makeOption(3)];


### PR DESCRIPTION
## Summary
- ensure the match creator quick date options format dates using the local timezone so weekday labels and dates stay aligned
- centralize local date/time formatting for default match data values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d603e5206c832885c7a52ec8aa8999