### PR TITLE
Align match format dropdown options

### DIFF
--- a/src/TennisMatchApp.jsx
+++ b/src/TennisMatchApp.jsx
@@ -66,6 +66,15 @@ import { formatPhoneNumber, normalizePhoneValue, formatPhoneDisplay } from "./se
 
 const DEFAULT_SKILL_LEVEL = "2.5 - Beginner";
 
+const matchFormatOptions = [
+  "Singles",
+  "Doubles",
+  "Mixed Doubles",
+  "Dingles",
+  "Round Robin",
+  "Other",
+];
+
 const getInitialPath = () => {
   if (typeof window === "undefined") return "/";
   const hash = window.location.hash || "";
@@ -2159,12 +2168,11 @@ const TennisMatchApp = () => {
                     }
                     className="w-full pl-11 pr-4 py-3.5 border-2 border-gray-200 rounded-xl focus:ring-2 focus:ring-green-500 focus:border-green-500 transition-colors appearance-none bg-white font-bold text-gray-800"
                   >
-                    <option>Doubles</option>
-                    <option>Singles</option>
-                    <option>Mixed Doubles</option>
-                    <option>Dingles</option>
-                    <option>Round Robin</option>
-                    <option>Other</option>
+                    {matchFormatOptions.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
                   </select>
                 </div>
               </div>

--- a/src/components/MatchCreatorFlow.jsx
+++ b/src/components/MatchCreatorFlow.jsx
@@ -80,6 +80,15 @@ const skillLevels = [
   { value: "4.5", label: "4.5+", desc: "Expert" },
 ];
 
+const matchFormatOptions = [
+  { value: "Singles", label: "Singles" },
+  { value: "Doubles", label: "Doubles" },
+  { value: "Mixed Doubles", label: "Mixed Doubles" },
+  { value: "Dingles", label: "Dingles" },
+  { value: "Round Robin", label: "Round Robin" },
+  { value: "Other", label: "Other" },
+];
+
 const timeSlots = [
   "06:00",
   "07:00",
@@ -900,10 +909,11 @@ const MatchCreatorFlow = ({ onCancel, onReturnHome, onMatchCreated, currentUser 
                   onChange={(e) => setMatchData((prev) => ({ ...prev, format: e.target.value }))}
                   className="flex-1 bg-transparent text-lg font-medium text-gray-900 focus:outline-none"
                 >
-                  <option value="Singles">Singles</option>
-                  <option value="Doubles">Doubles</option>
-                  <option value="Mixed Doubles">Mixed Doubles</option>
-                  <option value="Round Robin">Round Robin</option>
+                  {matchFormatOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
                 </select>
               </div>
             </div>
@@ -1207,10 +1217,11 @@ const MatchCreatorFlow = ({ onCancel, onReturnHome, onMatchCreated, currentUser 
                   onChange={(e) => setMatchData((prev) => ({ ...prev, format: e.target.value }))}
                   className="flex-1 bg-transparent text-lg font-medium text-gray-900 focus:outline-none"
                 >
-                  <option value="Singles">Singles</option>
-                  <option value="Doubles">Doubles</option>
-                  <option value="Mixed Doubles">Mixed Doubles</option>
-                  <option value="Round Robin">Round Robin</option>
+                  {matchFormatOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
                 </select>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add a shared list of match format options in the creator flow
- reuse the same match format options across the main app experience

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6e932cc38832aad8a6d8021051282