### PR TITLE
Filter out past matches from dashboard

### DIFF
--- a/src/TennisMatchApp.jsx
+++ b/src/TennisMatchApp.jsx
@@ -715,11 +715,19 @@ const TennisMatchApp = () => {
   }, [hasLocationFilter, locationFilter, matches]);
 
   const displayedMatches = useMemo(() => {
+    const now = Date.now();
+    const upcomingMatches = matchesWithDistance.filter((match) => {
+      if (!match?.dateTime) return true;
+      const matchStart = new Date(match.dateTime).getTime();
+      if (!Number.isFinite(matchStart)) return true;
+      return matchStart >= now;
+    });
+
     if (!hasLocationFilter) {
-      return matchesWithDistance;
+      return upcomingMatches;
     }
 
-    const filtered = matchesWithDistance.filter((match) => {
+    const filtered = upcomingMatches.filter((match) => {
       if (!Number.isFinite(match.distanceMiles)) return false;
       return match.distanceMiles <= distanceFilter;
     });


### PR DESCRIPTION
## Summary
- filter matches shown on the browse screen to exclude events whose start time is already in the past
- ensure distance filtering works on the reduced upcoming match list

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d802d48f908328b380fd466d33b77d