### PR TITLE
Fix double counted lesson spots by deduping participants

### DIFF
--- a/src/InvitationPage.jsx
+++ b/src/InvitationPage.jsx
@@ -20,6 +20,7 @@ import {
   claimInvite,
 } from "./services/invites";
 import { ARCHIVE_FILTER_VALUE, isMatchArchivedError } from "./utils/archive";
+import { uniqueActiveParticipants } from "./utils/participants";
 import Header from "./components/Header.jsx";
 
 export default function InvitationPage() {
@@ -1195,7 +1196,7 @@ function getActiveParticipants(match, preview) {
     ? preview.participants
     : [];
   const source = fromMatch.length ? fromMatch : fromPreview;
-  return source.filter((p) => p && p.status !== "left");
+  return uniqueActiveParticipants(source);
 }
 
 function participantDisplayName(participant) {

--- a/src/TennisMatchApp.jsx
+++ b/src/TennisMatchApp.jsx
@@ -69,7 +69,7 @@ import {
   isMatchArchivedError,
 } from "./utils/archive";
 import {
-  countUniqueAcceptedInvitees,
+  countUniqueMatchOccupants,
   idsMatch,
   uniqueActiveParticipants,
 } from "./utils/participants";
@@ -435,9 +435,10 @@ const TennisMatchApp = () => {
       setMatchPagination(data.pagination);
       let transformed = rawMatches.map((m) => {
         const activeParticipants = uniqueActiveParticipants(m.participants);
-        const participantCount = activeParticipants.length;
-        const acceptedInvites = countUniqueAcceptedInvitees(m.invitees);
-        const occupied = participantCount + acceptedInvites;
+        const occupied = countUniqueMatchOccupants(
+          m.participants,
+          m.invitees,
+        );
 
         const matchId = m.match_id || m.id;
         const isHost = m.host_id === currentUser?.id;
@@ -640,7 +641,6 @@ const TennisMatchApp = () => {
           : match.invitees || [];
 
         const validParticipants = uniqueActiveParticipants(participantsSource);
-        const acceptedInvites = countUniqueAcceptedInvitees(inviteesSource);
         const participantIds = validParticipants
           .map((p) => Number(p.player_id))
           .filter((id) => Number.isFinite(id) && id > 0);
@@ -659,7 +659,10 @@ const TennisMatchApp = () => {
           : match.host_profile?.full_name ||
             match.host_name ||
             (computedHostId ? `Player ${computedHostId}` : "");
-        const occupied = validParticipants.length + acceptedInvites;
+        const occupied = countUniqueMatchOccupants(
+          participantsSource,
+          inviteesSource,
+        );
 
         validParticipants.forEach((p) => {
           const pid = Number(p.player_id);

--- a/src/components/MatchDetailsModal.jsx
+++ b/src/components/MatchDetailsModal.jsx
@@ -16,6 +16,12 @@ import {
 import { joinMatch, removeParticipant } from "../services/matches";
 import { isMatchArchivedError } from "../utils/archive";
 import {
+  idsMatch,
+  uniqueAcceptedInvitees,
+  uniqueActiveParticipants,
+  uniqueParticipants,
+} from "../utils/participants";
+import {
   DEFAULT_EVENT_DURATION_MINUTES,
   downloadICSFile,
   ensureEventEnd,
@@ -88,8 +94,12 @@ const MatchDetailsModal = ({
 
   const match = matchData?.match || null;
   const participants = useMemo(() => {
-    if (Array.isArray(matchData?.participants)) return matchData.participants;
-    if (Array.isArray(match?.participants)) return match.participants;
+    if (Array.isArray(matchData?.participants)) {
+      return uniqueParticipants(matchData.participants);
+    }
+    if (Array.isArray(match?.participants)) {
+      return uniqueParticipants(match.participants);
+    }
     return [];
   }, [matchData, match]);
   const invitees = useMemo(() => {
@@ -100,7 +110,9 @@ const MatchDetailsModal = ({
 
   const hostParticipant = useMemo(() => {
     if (!match?.host_id) return null;
-    return participants.find((p) => p.player_id === match.host_id) || null;
+    return (
+      participants.find((p) => idsMatch(p.player_id, match.host_id)) || null
+    );
   }, [match?.host_id, participants]);
 
   const hostProfile = match?.host_profile || hostParticipant?.profile || null;
@@ -114,14 +126,16 @@ const MatchDetailsModal = ({
   const hostAvatar = hostProfile?.avatar_url || hostProfile?.avatar || null;
 
   const committedParticipants = useMemo(
-    () => participants.filter((p) => p.status !== "left"),
+    () => uniqueActiveParticipants(participants),
     [participants],
   );
 
-  const acceptedInviteCount = useMemo(
-    () => invitees.filter((invite) => invite.status === "accepted").length,
+  const acceptedInvitees = useMemo(
+    () => uniqueAcceptedInvitees(invitees),
     [invitees],
   );
+
+  const acceptedInviteCount = acceptedInvitees.length;
 
   const numericPlayerLimit = useMemo(() => {
     const candidate =
@@ -141,12 +155,17 @@ const MatchDetailsModal = ({
       ? null
       : Math.max(numericPlayerLimit - totalCommitted, 0);
 
-  const isHost = currentUser?.id && currentUser.id === match?.host_id;
-  const isParticipant = committedParticipants.some(
-    (p) => p.player_id === currentUser?.id,
+  const isHost =
+    currentUser?.id && match?.host_id
+      ? idsMatch(currentUser.id, match.host_id)
+      : false;
+  const isParticipant = committedParticipants.some((p) =>
+    idsMatch(p.player_id, currentUser?.id),
   );
-  const hasAcceptedInvite = invitees.some(
-    (invite) => invite.invitee_id === currentUser?.id && invite.status === "accepted",
+  const hasAcceptedInvite = acceptedInvitees.some(
+    (invite) =>
+      idsMatch(invite.invitee_id, currentUser?.id) ||
+      idsMatch(invite.player_id, currentUser?.id),
   );
   const isJoined = isHost || isParticipant || hasAcceptedInvite;
 

--- a/src/components/MatchDetailsModal.jsx
+++ b/src/components/MatchDetailsModal.jsx
@@ -16,6 +16,7 @@ import {
 import { joinMatch, removeParticipant } from "../services/matches";
 import { isMatchArchivedError } from "../utils/archive";
 import {
+  countUniqueMatchOccupants,
   idsMatch,
   uniqueAcceptedInvitees,
   uniqueActiveParticipants,
@@ -135,8 +136,6 @@ const MatchDetailsModal = ({
     [invitees],
   );
 
-  const acceptedInviteCount = acceptedInvitees.length;
-
   const numericPlayerLimit = useMemo(() => {
     const candidate =
       match?.player_limit ??
@@ -147,8 +146,7 @@ const MatchDetailsModal = ({
     return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
   }, [match]);
 
-  const totalCommitted =
-    committedParticipants.length + acceptedInviteCount;
+  const totalCommitted = countUniqueMatchOccupants(participants, invitees);
 
   const remainingSpots =
     numericPlayerLimit === null

--- a/src/pages/MatchPage.jsx
+++ b/src/pages/MatchPage.jsx
@@ -5,6 +5,7 @@ import { getMatch, removeParticipant } from "../services/matches";
 import { Calendar, MapPin, Users, ClipboardList, FileText, X } from "lucide-react";
 import Header from "../components/Header.jsx";
 import { ARCHIVE_FILTER_VALUE, isMatchArchivedError } from "../utils/archive";
+import { idsMatch, uniqueActiveParticipants } from "../utils/participants";
 
 export default function MatchPage() {
   const { id } = useParams();
@@ -65,7 +66,9 @@ export default function MatchPage() {
       await removeParticipant(data.match.id, playerId);
       setData({
         ...data,
-        participants: data.participants.filter((p) => p.player_id !== playerId),
+        participants: (data.participants || []).filter(
+          (p) => !idsMatch(p.player_id, playerId),
+        ),
       });
     } catch (error) {
       if (isMatchArchivedError(error)) {
@@ -97,8 +100,9 @@ export default function MatchPage() {
       </>
     );
 
-  const { match, participants = [] } = data;
-  const isHost = currentUser?.id === match.host_id;
+  const match = data.match;
+  const participants = uniqueActiveParticipants(data.participants || []);
+  const isHost = idsMatch(currentUser?.id, match.host_id);
 
   return (
     <>

--- a/src/utils/participants.js
+++ b/src/utils/participants.js
@@ -1,0 +1,108 @@
+const DEFAULT_IDENTITY_KEYS = ["player_id", "invitee_id", "id"];
+
+const normalizeIdentityValue = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const numeric = Number(trimmed);
+    if (Number.isFinite(numeric)) return numeric;
+    return trimmed;
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return numeric;
+  }
+  return null;
+};
+
+const buildIdentity = (item, keys = DEFAULT_IDENTITY_KEYS) => {
+  for (const key of keys) {
+    if (!Object.prototype.hasOwnProperty.call(item, key)) continue;
+    const identity = normalizeIdentityValue(item[key]);
+    if (identity !== null) {
+      return `${key}:${identity}`;
+    }
+  }
+  return null;
+};
+
+export const dedupeByIdentity = (items = [], keys = DEFAULT_IDENTITY_KEYS) => {
+  if (!Array.isArray(items) || items.length === 0) {
+    return [];
+  }
+  const seen = new Set();
+  const deduped = [];
+  for (const item of items) {
+    if (!item || typeof item !== "object") continue;
+    const identity = buildIdentity(item, keys);
+    if (identity) {
+      if (seen.has(identity)) continue;
+      seen.add(identity);
+    }
+    deduped.push(item);
+  }
+  return deduped;
+};
+
+export const uniqueParticipants = (participants = []) => {
+  if (!Array.isArray(participants)) return [];
+  return dedupeByIdentity(participants.filter(Boolean), [
+    "player_id",
+    "invitee_id",
+    "id",
+  ]);
+};
+
+export const uniqueActiveParticipants = (participants = []) =>
+  uniqueParticipants(participants).filter((participant) =>
+    participant?.status ? participant.status !== "left" : true,
+  );
+
+export const countUniqueActiveParticipants = (participants = []) =>
+  uniqueActiveParticipants(participants).length;
+
+export const uniqueInvitees = (invitees = []) => {
+  if (!Array.isArray(invitees)) return [];
+  return dedupeByIdentity(invitees.filter(Boolean), [
+    "invitee_id",
+    "player_id",
+    "id",
+  ]);
+};
+
+export const uniqueAcceptedInvitees = (invitees = []) =>
+  dedupeByIdentity(
+    Array.isArray(invitees)
+      ? invitees.filter(
+          (invite) => invite && invite.status === "accepted",
+        )
+      : [],
+    ["invitee_id", "player_id", "id"],
+  );
+
+export const countUniqueAcceptedInvitees = (invitees = []) =>
+  uniqueAcceptedInvitees(invitees).length;
+
+const normalizeForComparison = (value) => {
+  const normalized = normalizeIdentityValue(value);
+  if (typeof normalized === "string") {
+    return normalized.toLowerCase();
+  }
+  return normalized;
+};
+
+export const idsMatch = (a, b) => {
+  const left = normalizeForComparison(a);
+  const right = normalizeForComparison(b);
+  if (left === null || right === null) return false;
+  return left === right;
+};

--- a/src/utils/participants.js
+++ b/src/utils/participants.js
@@ -70,6 +70,30 @@ export const uniqueActiveParticipants = (participants = []) =>
 export const countUniqueActiveParticipants = (participants = []) =>
   uniqueActiveParticipants(participants).length;
 
+export const uniqueMatchOccupants = (
+  participants = [],
+  invitees = [],
+) => {
+  const activeParticipants = uniqueActiveParticipants(participants);
+  const acceptedInvitees = uniqueAcceptedInvitees(invitees);
+
+  if (acceptedInvitees.length === 0) {
+    return activeParticipants;
+  }
+
+  if (activeParticipants.length === 0) {
+    return acceptedInvitees;
+  }
+
+  return dedupeByIdentity(
+    [...activeParticipants, ...acceptedInvitees],
+    ["player_id", "invitee_id", "id"],
+  );
+};
+
+export const countUniqueMatchOccupants = (participants = [], invitees = []) =>
+  uniqueMatchOccupants(participants, invitees).length;
+
 export const uniqueInvitees = (invitees = []) => {
   if (!Array.isArray(invitees)) return [];
   return dedupeByIdentity(invitees.filter(Boolean), [


### PR DESCRIPTION
## Summary
- add participant identity helpers to ensure rosters and invite lists are unique and comparable by id
- update booking, invite, and match management flows to use the helpers so occupancy counts and host controls ignore duplicate rows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3fc1972988328a8b0c8b85d0ec582