### PR TITLE
Fix match invitation player count display

### DIFF
--- a/src/InvitationPage.jsx
+++ b/src/InvitationPage.jsx
@@ -485,8 +485,9 @@ export default function InvitationPage() {
       : preview?.inviter
         ? [{ profile: { full_name: preview.inviter.full_name } }]
         : [];
-  const effectivePlayers =
-    occupancyFromMatch ?? (participants.length ? participants.length : null);
+  const effectivePlayers = participants.length
+    ? participants.length
+    : occupancyFromMatch ?? null;
   const occupancyLabel = playerLimit
     ? `${effectivePlayers ?? avatarPlayers.length}/${playerLimit}`
     : effectivePlayers ?? avatarPlayers.length


### PR DESCRIPTION
## Summary
- ensure the match invitation page uses the rendered participant list when showing player occupancy
- prevent the host from being double-counted when match metadata reports a higher player total

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e406afe6088328a17e04a5cb99a455