### PR TITLE
Fix leaving match roster state

### DIFF
--- a/src/components/MatchDetailsModal.jsx
+++ b/src/components/MatchDetailsModal.jsx
@@ -410,6 +410,37 @@ const MatchDetailsModal = ({
       setLeaving(true);
       await leaveMatch(match.id);
       onToast?.("You're off the roster. We'll notify the organizer.");
+      const pruneCurrentUserFromMatch = (data) => {
+        if (!data || !currentUser?.id) return data;
+        const userId = currentUser.id;
+        const removeUser = (items) => {
+          if (!Array.isArray(items)) return items;
+          return items.filter(
+            (item) =>
+              !idsMatch(item?.player_id, userId) &&
+              !idsMatch(item?.invitee_id, userId) &&
+              !idsMatch(item?.id, userId),
+          );
+        };
+        const next = { ...data };
+        if (Array.isArray(next.participants)) {
+          next.participants = removeUser(next.participants);
+        }
+        if (Array.isArray(next.invitees)) {
+          next.invitees = removeUser(next.invitees);
+        }
+        if (next.match && typeof next.match === "object") {
+          next.match = { ...next.match };
+          if (Array.isArray(next.match.participants)) {
+            next.match.participants = removeUser(next.match.participants);
+          }
+          if (Array.isArray(next.match.invitees)) {
+            next.match.invitees = removeUser(next.match.invitees);
+          }
+        }
+        return next;
+      };
+      onUpdateMatch?.((prev) => pruneCurrentUserFromMatch(prev));
       setStatus("details");
       await onMatchRefresh?.();
       if (onReloadMatch && onUpdateMatch) {


### PR DESCRIPTION
## Summary
- ensure match transformations ignore stale joined timestamps when a player has departure markers and account for accepted invites when deriving joined state
- prune the current player from local match detail state immediately after leaving so participant counts update without waiting for a reload

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e40e5b2c788328945c8e72914f625a