### PR TITLE
Fix leave match state persistence

### DIFF
--- a/src/TennisMatchApp.jsx
+++ b/src/TennisMatchApp.jsx
@@ -519,12 +519,22 @@ const TennisMatchApp = () => {
                 idsMatch(participant?.invitee_id, currentUser?.id),
             )
           : null;
+        const joinedTimestamp =
+          m.joined_at ??
+          m.joinedAt ??
+          m.joined ??
+          participantRecord?.joined_at ??
+          participantRecord?.joinedAt ??
+          participantRecord?.joined;
         const hasDeparted =
           hasAnyValue(m, DEPARTURE_KEYS) ||
           hasAnyValue(participantRecord, DEPARTURE_KEYS) ||
           hasInactiveStatus(m) ||
-          hasInactiveStatus(participantRecord);
-        const joinedTimestampActive = Boolean(m.joined_at) && !hasDeparted;
+          hasInactiveStatus(participantRecord) ||
+          (Boolean(joinedTimestamp) &&
+            !hasActiveParticipant &&
+            !hasAcceptedInvite);
+        const joinedTimestampActive = Boolean(joinedTimestamp) && !hasDeparted;
         const isJoined =
           !isHost &&
           (hasActiveParticipant || hasAcceptedInvite || joinedTimestampActive);

--- a/src/TennisMatchApp.jsx
+++ b/src/TennisMatchApp.jsx
@@ -71,6 +71,7 @@ import {
 import {
   countUniqueMatchOccupants,
   idsMatch,
+  pruneParticipantFromMatchData,
   uniqueAcceptedInvitees,
   uniqueActiveParticipants,
 } from "./utils/participants";
@@ -1924,6 +1925,57 @@ const TennisMatchApp = () => {
               onClick={async () => {
                 try {
                   await leaveMatch(matchId);
+                  setMatches((prevMatches) => {
+                    if (!Array.isArray(prevMatches)) return prevMatches;
+                    const updated = [];
+                    for (const match of prevMatches) {
+                      if (!match || match.id !== matchId) {
+                        updated.push(match);
+                        continue;
+                      }
+                      const pruned = pruneParticipantFromMatchData(
+                        match,
+                        currentUser?.id,
+                      );
+                      const participants = Array.isArray(pruned?.participants)
+                        ? pruned.participants
+                        : Array.isArray(match.participants)
+                        ? match.participants
+                        : [];
+                      const invitees = Array.isArray(pruned?.invitees)
+                        ? pruned.invitees
+                        : Array.isArray(match.invitees)
+                        ? match.invitees
+                        : [];
+                      const occupied = countUniqueMatchOccupants(
+                        participants,
+                        invitees,
+                      );
+                      const playerLimit = Number.isFinite(match.playerLimit)
+                        ? match.playerLimit
+                        : Number.isFinite(pruned?.playerLimit)
+                        ? pruned.playerLimit
+                        : null;
+                      const spotsAvailable =
+                        playerLimit !== null
+                          ? Math.max(playerLimit - occupied, 0)
+                          : pruned?.spotsAvailable ??
+                            match.spotsAvailable ??
+                            null;
+                      const nextMatch = {
+                        ...match,
+                        ...pruned,
+                        type: match.type === "hosted" ? "hosted" : "available",
+                        occupied,
+                        spotsAvailable,
+                      };
+                      if (activeFilter === "joined" && nextMatch.type !== "hosted") {
+                        continue;
+                      }
+                      updated.push(nextMatch);
+                    }
+                    return updated;
+                  });
                   displayToast("Left match");
                   onClose();
                   fetchMatches();

--- a/src/components/MatchDetailsModal.jsx
+++ b/src/components/MatchDetailsModal.jsx
@@ -27,6 +27,7 @@ import { isMatchArchivedError } from "../utils/archive";
 import {
   countUniqueMatchOccupants,
   idsMatch,
+  pruneParticipantFromMatchData,
   uniqueAcceptedInvitees,
   uniqueActiveParticipants,
   uniqueParticipants,
@@ -577,37 +578,9 @@ const MatchDetailsModal = ({
       setLeaving(true);
       await leaveMatch(match.id);
       onToast?.("You're off the roster. We'll notify the organizer.");
-      const pruneCurrentUserFromMatch = (data) => {
-        if (!data || !currentUser?.id) return data;
-        const userId = currentUser.id;
-        const removeUser = (items) => {
-          if (!Array.isArray(items)) return items;
-          return items.filter(
-            (item) =>
-              !idsMatch(item?.player_id, userId) &&
-              !idsMatch(item?.invitee_id, userId) &&
-              !idsMatch(item?.id, userId),
-          );
-        };
-        const next = { ...data };
-        if (Array.isArray(next.participants)) {
-          next.participants = removeUser(next.participants);
-        }
-        if (Array.isArray(next.invitees)) {
-          next.invitees = removeUser(next.invitees);
-        }
-        if (next.match && typeof next.match === "object") {
-          next.match = { ...next.match };
-          if (Array.isArray(next.match.participants)) {
-            next.match.participants = removeUser(next.match.participants);
-          }
-          if (Array.isArray(next.match.invitees)) {
-            next.match.invitees = removeUser(next.match.invitees);
-          }
-        }
-        return next;
-      };
-      onUpdateMatch?.((prev) => pruneCurrentUserFromMatch(prev));
+      onUpdateMatch?.((prev) =>
+        pruneParticipantFromMatchData(prev, currentUser.id),
+      );
       setStatus("details");
       await onMatchRefresh?.();
       if (onReloadMatch && onUpdateMatch) {

--- a/src/utils/participants.js
+++ b/src/utils/participants.js
@@ -262,12 +262,38 @@ const pruneItemsByIdentity = (items, memberId) => {
   });
 };
 
+const JOIN_METADATA_KEYS = [
+  "joined_at",
+  "joinedAt",
+  "joined",
+  "joined_on",
+  "joinedOn",
+  "joined_by_player_id",
+  "joinedByPlayerId",
+  "joined_player_id",
+  "joinedPlayerId",
+  "joined_status",
+  "joinedStatus",
+  "is_joined",
+  "isJoined",
+];
+
+const clearJoinMetadata = (target) => {
+  if (!target || typeof target !== "object") return target;
+  for (const key of JOIN_METADATA_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(target, key)) {
+      delete target[key];
+    }
+  }
+  return target;
+};
+
 const pruneParticipantCollections = (target, memberId, seen) => {
   if (!target || typeof target !== "object") return target;
   if (seen.has(target)) return target;
   seen.add(target);
 
-  const next = { ...target };
+  const next = clearJoinMetadata({ ...target });
 
   if (Array.isArray(next.participants)) {
     next.participants = pruneItemsByIdentity(next.participants, memberId);
@@ -279,6 +305,7 @@ const pruneParticipantCollections = (target, memberId, seen) => {
 
   if (next.match && typeof next.match === "object") {
     next.match = pruneParticipantCollections(next.match, memberId, seen);
+    clearJoinMetadata(next.match);
   }
 
   return next;


### PR DESCRIPTION
## Summary
- add a shared helper to prune a participant from match data structures
- ensure the leave match action updates the local match list immediately
- reuse the pruning helper inside the match details modal for consistency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e41cf2b2808328899b284318f1967a