### PR TITLE
feat: add match editing workflow

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { createHashRouter, RouterProvider, Navigate } from "react-router-dom";
+import { QueryClientProvider, createQueryClient } from "@tanstack/react-query";
 import InvitationPage from "./InvitationPage.jsx";
 import MatchPage from "./pages/MatchPage.jsx";
 import ResetPassword from "./pages/ResetPassword.jsx";
@@ -30,8 +31,12 @@ const router = createHashRouter([
   { path: "*", element: <Navigate to="/" replace /> },
 ]);
 
+const queryClient = createQueryClient();
+
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/src/pages/MatchPage.jsx
+++ b/src/pages/MatchPage.jsx
@@ -1,18 +1,99 @@
 // src/pages/MatchPage.jsx
-import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
-import { getMatch, removeParticipant } from "../services/matches";
-import { Calendar, MapPin, Users, ClipboardList, FileText, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  Calendar,
+  MapPin,
+  Users,
+  ClipboardList,
+  FileText,
+  X,
+  Share2,
+  Link as LinkIcon,
+  Pencil,
+  AlertCircle,
+  CheckCircle2,
+} from "lucide-react";
 import Header from "../components/Header.jsx";
 import { ARCHIVE_FILTER_VALUE, isMatchArchivedError } from "../utils/archive";
-import { idsMatch, uniqueActiveParticipants } from "../utils/participants";
+import {
+  idsMatch,
+  uniqueActiveParticipants,
+} from "../utils/participants";
+import {
+  getMatch,
+  getShareLink,
+  removeParticipant,
+  updateMatch,
+} from "../services/matches";
+
+const DEFAULT_FORM = {
+  date: "",
+  time: "",
+  location: "",
+  matchFormat: "",
+  level: "",
+  notes: "",
+};
+
+const toDateInput = (value) => {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const toTimeInput = (value) => {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const hours = `${date.getHours()}`.padStart(2, "0");
+  const minutes = `${date.getMinutes()}`.padStart(2, "0");
+  return `${hours}:${minutes}`;
+};
+
+const combineDateTime = (date, time) => {
+  if (!date || !time) return null;
+  const timestamp = new Date(`${date}T${time}`);
+  if (Number.isNaN(timestamp.getTime())) return null;
+  return timestamp.toISOString();
+};
+
+const buildInitialForm = (match) => {
+  if (!match) return { ...DEFAULT_FORM };
+  return {
+    date: toDateInput(match.start_date_time),
+    time: toTimeInput(match.start_date_time),
+    location: match.location_text || match.location || "",
+    matchFormat: match.match_format || match.format || "",
+    level: match.skill_level || match.skill_level_min || "",
+    notes: match.notes || "",
+  };
+};
+
+const sanitizePayload = (payload) =>
+  Object.fromEntries(
+    Object.entries(payload).filter(([, value]) => value !== undefined),
+  );
 
 export default function MatchPage() {
   const { id } = useParams();
-  const [data, setData] = useState(null);
-  const [err, setErr] = useState("");
-  const [removeError, setRemoveError] = useState("");
-  const [archived, setArchived] = useState(false);
+  const queryClient = useQueryClient();
+  const [isEditing, setIsEditing] = useState(false);
+  const [formState, setFormState] = useState(DEFAULT_FORM);
+  const [formError, setFormError] = useState("");
+  const [feedback, setFeedback] = useState(null);
+  const [shareLink, setShareLink] = useState("");
+  const [shareCopied, setShareCopied] = useState(false);
+  const [removingId, setRemovingId] = useState(null);
 
   const [currentUser] = useState(() => {
     try {
@@ -23,74 +104,229 @@ export default function MatchPage() {
     }
   });
 
-  useEffect(() => {
-    let alive = true;
-    (async () => {
+  const {
+    data,
+    error,
+    isError,
+    isLoading,
+  } = useQuery({
+    queryKey: ["match", id],
+    enabled: Boolean(id),
+    retry: false,
+    queryFn: async () => {
+      if (!id) return null;
       try {
-        const loadMatch = async () => {
-          try {
-            return await getMatch(id);
-          } catch (error) {
-            if (!isMatchArchivedError(error)) throw error;
-            return await getMatch(id, { filter: ARCHIVE_FILTER_VALUE });
-          }
-        };
-
-        const resp = await loadMatch();
-        if (!alive) return;
-        setArchived(resp?.match?.status === "archived");
-        setData(resp);
-      } catch (error) {
-        if (isMatchArchivedError(error)) {
-          setArchived(true);
-          setErr("This match has been archived and is no longer accessible.");
-        } else {
-          setErr("Not found or access denied.");
-        }
+        return await getMatch(id);
+      } catch (err) {
+        if (!isMatchArchivedError(err)) throw err;
+        return await getMatch(id, { filter: ARCHIVE_FILTER_VALUE });
       }
-    })();
-    return () => {
-      alive = false;
-    };
-  }, [id]);
+    },
+  });
 
-  const handleRemoveParticipant = async (playerId) => {
-    if (!data) return;
-    if (!window.confirm("Remove this participant from the match?")) return;
-    if (archived) {
-      setRemoveError("This match has been archived. Participants cannot be removed.");
-      setTimeout(() => setRemoveError(""), 3000);
+  const match = data?.match || null;
+  const participants = useMemo(
+    () => uniqueActiveParticipants(data?.participants || []),
+    [data?.participants],
+  );
+
+  const originalForm = useMemo(() => buildInitialForm(match), [match]);
+
+  useEffect(() => {
+    setFormState(originalForm);
+  }, [originalForm]);
+
+  useEffect(() => {
+    if (shareLink) setShareCopied(false);
+  }, [shareLink]);
+
+  const archived = match?.status === "archived";
+  const cancelled = match?.status === "cancelled";
+  const isPrivate = match?.privacy === "private";
+  const isOpenMatch = Boolean(match) && !isPrivate;
+  const isHost = Boolean(match?.host_id) && idsMatch(currentUser?.id, match.host_id);
+  const canEdit = isHost && !archived && !cancelled;
+
+  const hasChanges = useMemo(() => {
+    return JSON.stringify(formState) !== JSON.stringify(originalForm);
+  }, [formState, originalForm]);
+
+  const scheduleChanged =
+    originalForm.date !== formState.date ||
+    originalForm.time !== formState.time ||
+    originalForm.location.trim() !== formState.location.trim();
+
+  const updateMatchMutation = useMutation({
+    mutationFn: async (updates) => {
+      if (!match?.id) return null;
+      return updateMatch(match.id, updates);
+    },
+    onSuccess: async () => {
+      setFeedback({ type: "success", message: "Match updated successfully." });
+      setFormError("");
+      setIsEditing(false);
+      await queryClient.invalidateQueries({ queryKey: ["match", id] });
+    },
+    onError: (err) => {
+      const message =
+        err?.response?.data?.message || err?.message || "Failed to update match.";
+      setFeedback({ type: "error", message });
+    },
+  });
+
+  const removeParticipantMutation = useMutation({
+    mutationFn: async (playerId) => {
+      if (!match?.id) return null;
+      return removeParticipant(match.id, playerId);
+    },
+    onSuccess: (_, playerId) => {
+      queryClient.setQueryData(["match", id], (prev) => {
+        if (!prev) return prev;
+        const filtered = (prev.participants || []).filter(
+          (participant) => !idsMatch(participant.player_id, playerId),
+        );
+        return { ...prev, participants: filtered };
+      });
+      setFeedback({ type: "success", message: "Participant removed." });
+    },
+    onError: (err) => {
+      const message =
+        err?.response?.data?.message || err?.message || "Failed to remove participant.";
+      setFeedback({ type: "error", message });
+    },
+  });
+
+  const shareLinkMutation = useMutation({
+    mutationFn: async () => {
+      if (!match?.id) return null;
+      return getShareLink(match.id);
+    },
+    onSuccess: (result) => {
+      const link = result?.shareUrl || result?.share_url || result?.url || "";
+      if (!link) {
+        setFeedback({
+          type: "error",
+          message: "We couldn't generate a share link. Try again.",
+        });
+        setShareLink("");
+        return;
+      }
+      setShareLink(link);
+      setFeedback({ type: "success", message: "Share link ready to copy." });
+    },
+    onError: (err) => {
+      const message =
+        err?.response?.data?.message ||
+        err?.message ||
+        "We couldn't generate a share link. Try again.";
+      setFeedback({ type: "error", message });
+    },
+  });
+
+  const handleEditToggle = () => {
+    if (!canEdit) return;
+    setFeedback(null);
+    setFormError("");
+    setIsEditing((prev) => !prev);
+  };
+
+  const handleFormChange = (field, value) => {
+    setFormState((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleCancel = () => {
+    setFormState(originalForm);
+    setIsEditing(false);
+    setFormError("");
+    setFeedback(null);
+  };
+
+  const handleSave = async (event) => {
+    event.preventDefault();
+    if (!match?.id) return;
+    setFormError("");
+    setFeedback(null);
+    const trimmedLocation = formState.location.trim();
+    if (!formState.date || !formState.time || !trimmedLocation) {
+      setFormError("Date, time, and location are required.");
       return;
     }
+    const isoDate = combineDateTime(formState.date, formState.time);
+    if (!isoDate) {
+      setFormError("Please provide a valid date and time.");
+      return;
+    }
+    if (scheduleChanged) {
+      const confirmed = window.confirm(
+        "Changing the schedule will notify participants. Continue?",
+      );
+      if (!confirmed) return;
+    }
+
+    const matchFormat = formState.matchFormat.trim();
+    const notes = formState.notes.trim();
+    const level = formState.level.trim();
+    const payload = sanitizePayload({
+      start_date_time: isoDate,
+      location_text: trimmedLocation,
+      location: trimmedLocation,
+      match_format: matchFormat || null,
+      notes: notes || null,
+      ...(isOpenMatch
+        ? {
+            skill_level: level || null,
+            skill_level_min: level || null,
+          }
+        : {}),
+    });
+
     try {
-      await removeParticipant(data.match.id, playerId);
-      setData({
-        ...data,
-        participants: (data.participants || []).filter(
-          (p) => !idsMatch(p.player_id, playerId),
-        ),
-      });
-    } catch (error) {
-      if (isMatchArchivedError(error)) {
-        setArchived(true);
-        setRemoveError("This match has been archived. Participants cannot be removed.");
-      } else {
-        setRemoveError("Failed to remove participant");
-      }
-      setTimeout(() => setRemoveError(""), 3000);
+      await updateMatchMutation.mutateAsync(payload);
+    } catch {
+      // mutation handles error state
     }
   };
 
-  if (err)
-    return (
-      <>
-        <Header />
-        <Page>
-          <Alert>{err}</Alert>
-        </Page>
-      </>
-    );
-  if (!data)
+  const handleRemoveParticipant = async (playerId) => {
+    if (!canEdit || !match?.id) return;
+    const participant = participants.find((p) => idsMatch(p.player_id, playerId));
+    if (participant && idsMatch(participant.player_id, match.host_id)) return;
+    if (!window.confirm("Remove this participant from the match?")) return;
+    setRemovingId(playerId);
+    try {
+      await removeParticipantMutation.mutateAsync(playerId);
+    } catch {
+      // handled in mutation
+    } finally {
+      setRemovingId(null);
+    }
+  };
+
+  const handleGenerateShareLink = async () => {
+    setShareCopied(false);
+    try {
+      await shareLinkMutation.mutateAsync();
+    } catch {
+      // handled in mutation
+    }
+  };
+
+  const handleCopyShareLink = async () => {
+    if (!shareLink) return;
+    try {
+      await navigator.clipboard.writeText(shareLink);
+      setShareCopied(true);
+      setFeedback({ type: "success", message: "Link copied to clipboard." });
+    } catch {
+      setShareCopied(false);
+      setFeedback({
+        type: "error",
+        message: "Unable to copy link. Copy it manually instead.",
+      });
+    }
+  };
+
+  if (isLoading)
     return (
       <>
         <Header />
@@ -100,95 +336,378 @@ export default function MatchPage() {
       </>
     );
 
-  const match = data.match;
-  const participants = uniqueActiveParticipants(data.participants || []);
-  const isHost = idsMatch(currentUser?.id, match.host_id);
+  if (isError)
+    return (
+      <>
+        <Header />
+        <Page>
+          <Alert>
+            {isMatchArchivedError(error)
+              ? "This match has been archived and is no longer accessible."
+              : "Not found or access denied."}
+          </Alert>
+        </Page>
+      </>
+    );
+
+  if (!match)
+    return (
+      <>
+        <Header />
+        <Page>
+          <Alert>Match unavailable.</Alert>
+        </Page>
+      </>
+    );
 
   return (
     <>
       <Header />
       <Page>
-      <h1 className="text-xl font-bold mb-2">Match Details</h1>
-      {data?.match?.status === "cancelled" && (
-        <div className="mb-4">
-          <span className="inline-block px-3 py-1.5 bg-gradient-to-r from-red-50 to-rose-50 text-red-700 border border-red-200 rounded-full text-xs font-black">
-            CANCELLED
-          </span>
-        </div>
-      )}
-      {archived && (
-        <div className="mb-4">
-          <span className="inline-block px-3 py-1.5 bg-gradient-to-r from-slate-100 to-slate-200 text-slate-700 border border-slate-300 rounded-full text-xs font-black">
-            ARCHIVED
-          </span>
-          <p className="mt-2 text-sm text-slate-600 font-semibold">
-            This match has been archived. Actions are disabled.
-          </p>
-        </div>
-      )}
-      <div className="space-y-1 mb-6">
-        <p className="flex items-center gap-1 text-gray-700">
-          <Calendar className="w-4 h-4" />
-          {new Date(match.start_date_time).toLocaleString()}
-        </p>
-        {match.location_text && (
-          <p className="flex items-center gap-1 text-gray-700">
-            <MapPin className="w-4 h-4" /> {match.location_text}
-          </p>
-        )}
-        {match.match_format && (
-          <p className="flex items-center gap-1 text-gray-700">
-            <ClipboardList className="w-4 h-4" /> {match.match_format}
-          </p>
-        )}
-        {match.notes && (
-          <p className="flex items-center gap-1 text-gray-700">
-            <FileText className="w-4 h-4" /> {match.notes}
-          </p>
-        )}
-      </div>
-      <div>
-        <h2 className="text-lg font-bold mb-2 flex items-center gap-1">
-          <Users className="w-4 h-4" /> Participants
-        </h2>
-        {removeError && <p className="text-red-600 mb-2">{removeError}</p>}
-        {participants.length ? (
-          <ul className="space-y-1">
-            {participants.map((p) => (
-              <li
-                key={p.id}
-                className="flex items-center justify-between text-gray-700"
+        <header className="mb-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h1 className="text-xl font-bold text-gray-900">Match Details</h1>
+              <p className="text-sm text-gray-500">
+                Hosted by {match.host_name || "Match Organizer"}
+              </p>
+            </div>
+            {canEdit && (
+              <button
+                type="button"
+                onClick={handleEditToggle}
+                className="inline-flex items-center gap-2 self-start rounded-lg border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm transition hover:border-gray-300 hover:bg-gray-50"
               >
-                <span>
-                  {p.profile?.full_name || `Player ${p.player_id}`}
-                  {p.player_id === match.host_id && (
-                    <span className="ml-1 text-blue-700 text-xs">Host</span>
-                  )}
-                </span>
-                {isHost && !archived && p.player_id !== match.host_id && (
-                  <button
-                    onClick={() => handleRemoveParticipant(p.player_id)}
-                    className="text-red-600 hover:text-red-800"
-                    aria-label="Remove participant"
-                  >
-                    <X className="w-4 h-4" />
-                  </button>
-                )}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="text-gray-500">No participants yet.</p>
+                <Pencil className="h-4 w-4" />
+                {isEditing ? "Close editor" : "Edit match"}
+              </button>
+            )}
+          </div>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {cancelled && (
+              <Badge intent="warning">CANCELLED</Badge>
+            )}
+            {archived && <Badge intent="neutral">ARCHIVED</Badge>}
+          </div>
+        </header>
+
+        {feedback && (
+          <div
+            className={`mb-6 flex items-start gap-2 rounded-lg border px-4 py-3 text-sm font-semibold ${
+              feedback.type === "error"
+                ? "border-red-200 bg-red-50 text-red-700"
+                : "border-emerald-200 bg-emerald-50 text-emerald-700"
+            }`}
+          >
+            {feedback.type === "error" ? (
+              <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            ) : (
+              <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            )}
+            <span>{feedback.message}</span>
+          </div>
         )}
-      </div>
+
+        <section className="mb-6 rounded-xl border border-gray-100 bg-white p-5 shadow-sm">
+          {isEditing ? (
+            <form className="space-y-5" onSubmit={handleSave}>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <Field label="Date" required>
+                  <input
+                    type="date"
+                    value={formState.date}
+                    onChange={(event) =>
+                      handleFormChange("date", event.target.value)
+                    }
+                    className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-900 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                  />
+                </Field>
+                <Field label="Time" required>
+                  <input
+                    type="time"
+                    value={formState.time}
+                    onChange={(event) =>
+                      handleFormChange("time", event.target.value)
+                    }
+                    className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-900 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                  />
+                </Field>
+              </div>
+              <Field label="Location" required>
+                <input
+                  type="text"
+                  value={formState.location}
+                  onChange={(event) =>
+                    handleFormChange("location", event.target.value)
+                  }
+                  placeholder="Court name or address"
+                  className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-900 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                />
+              </Field>
+              {isOpenMatch && (
+                <Field label="Level">
+                  <select
+                    value={formState.level}
+                    onChange={(event) =>
+                      handleFormChange("level", event.target.value)
+                    }
+                    className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-900 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                  >
+                    <option value="">Select level</option>
+                    {["2.0", "2.5", "3.0", "3.5", "4.0", "4.5", "5.0"].map(
+                      (level) => (
+                        <option key={level} value={level}>
+                          {level}
+                        </option>
+                      ),
+                    )}
+                  </select>
+                </Field>
+              )}
+              <Field label="Match format">
+                <select
+                  value={formState.matchFormat}
+                  onChange={(event) =>
+                    handleFormChange("matchFormat", event.target.value)
+                  }
+                  className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-900 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                >
+                  <option value="">Select format</option>
+                  <option value="Singles">Singles</option>
+                  <option value="Doubles">Doubles</option>
+                  <option value="Rotation">Rotation format</option>
+                </select>
+              </Field>
+              <Field label="Notes">
+                <textarea
+                  value={formState.notes}
+                  onChange={(event) =>
+                    handleFormChange("notes", event.target.value)
+                  }
+                  rows={4}
+                  placeholder="Add context, scoring, or reminders"
+                  className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-900 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                />
+              </Field>
+
+              {formError && (
+                <p className="text-sm font-semibold text-red-600">{formError}</p>
+              )}
+
+              <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:justify-end">
+                <button
+                  type="button"
+                  onClick={handleCancel}
+                  className="inline-flex justify-center rounded-lg border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-700 transition hover:bg-gray-50"
+                  disabled={updateMatchMutation.isPending}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={
+                    updateMatchMutation.isPending || !hasChanges || !formState.date || !formState.time
+                  }
+                  className="inline-flex justify-center rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-emerald-300"
+                >
+                  {updateMatchMutation.isPending ? "Saving…" : "Save changes"}
+                </button>
+              </div>
+            </form>
+          ) : (
+            <div className="space-y-4">
+              <div className="space-y-2 text-sm text-gray-700">
+                <DetailRow icon={Calendar}>
+                  {match.start_date_time
+                    ? new Date(match.start_date_time).toLocaleString()
+                    : "Date to be announced"}
+                </DetailRow>
+                {match.location_text && (
+                  <DetailRow icon={MapPin}>{match.location_text}</DetailRow>
+                )}
+                {match.match_format && (
+                  <DetailRow icon={ClipboardList}>{match.match_format}</DetailRow>
+                )}
+                {isOpenMatch && match.skill_level && (
+                  <DetailRow icon={Users}>
+                    Skill level: {match.skill_level}
+                  </DetailRow>
+                )}
+                {match.notes && (
+                  <DetailRow icon={FileText}>{match.notes}</DetailRow>
+                )}
+              </div>
+            </div>
+          )}
+        </section>
+
+        <section className="mb-6 rounded-xl border border-gray-100 bg-white p-5 shadow-sm">
+          <header className="mb-4 flex items-center justify-between">
+            <h2 className="flex items-center gap-2 text-lg font-semibold text-gray-900">
+              <Users className="h-5 w-5 text-gray-500" /> Participants
+            </h2>
+            <span className="text-sm font-medium text-gray-500">
+              {participants.length} player{participants.length === 1 ? "" : "s"}
+            </span>
+          </header>
+          {participants.length ? (
+            <ul className="divide-y divide-gray-100">
+              {participants.map((participant) => {
+                const name =
+                  participant.profile?.full_name ||
+                  participant.profile?.name ||
+                  `Player ${participant.player_id}`;
+                const isHostParticipant = idsMatch(
+                  participant.player_id,
+                  match.host_id,
+                );
+                return (
+                  <li
+                    key={participant.id || participant.player_id}
+                    className="flex items-center justify-between py-3 text-sm text-gray-700"
+                  >
+                    <div className="flex flex-col">
+                      <span className="font-semibold text-gray-900">{name}</span>
+                      {isHostParticipant && (
+                        <span className="text-xs font-semibold uppercase tracking-wide text-emerald-600">
+                          Host
+                        </span>
+                      )}
+                    </div>
+                    {canEdit && !isHostParticipant ? (
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveParticipant(participant.player_id)}
+                        disabled={removingId === participant.player_id || removeParticipantMutation.isPending}
+                        className="inline-flex items-center gap-1 rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        <X className="h-4 w-4" />
+                        {removingId === participant.player_id
+                          ? "Removing…"
+                          : "Remove"}
+                      </button>
+                    ) : (
+                      <span className="text-xs text-gray-400">{isHostParticipant ? "Organizer" : ""}</span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <p className="text-sm text-gray-500">No participants yet.</p>
+          )}
+        </section>
+
+        {isHost && (
+          <section className="mb-10 rounded-xl border border-gray-100 bg-white p-5 shadow-sm">
+            <h2 className="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-900">
+              {isOpenMatch ? (
+                <>
+                  <Share2 className="h-5 w-5 text-gray-500" /> Share this match
+                </>
+              ) : (
+                <>
+                  <Users className="h-5 w-5 text-gray-500" /> Invite players
+                </>
+              )}
+            </h2>
+            {isOpenMatch ? (
+              <div className="space-y-3">
+                <p className="text-sm text-gray-600">
+                  Generate a public link to share with potential players.
+                </p>
+                {shareLink && (
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                    <div className="flex flex-1 items-center gap-2 rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-700">
+                      <LinkIcon className="h-4 w-4 text-gray-400" />
+                      <span className="truncate">{shareLink}</span>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={handleCopyShareLink}
+                      className="inline-flex items-center justify-center rounded-lg bg-gray-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-gray-700"
+                    >
+                      {shareCopied ? "Copied" : "Copy link"}
+                    </button>
+                  </div>
+                )}
+                <button
+                  type="button"
+                  onClick={handleGenerateShareLink}
+                  disabled={shareLinkMutation.isPending}
+                  className="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-700 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <Share2 className="h-4 w-4" />
+                  {shareLinkMutation.isPending ? "Generating…" : "Generate share link"}
+                </button>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <p className="text-sm text-gray-600">
+                  Use the invite flow to add players directly.
+                </p>
+                <Link
+                  to={`/matches/${match.id}/invite`}
+                  className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700"
+                >
+                  <Users className="h-4 w-4 text-white" />
+                  Open invite manager
+                </Link>
+              </div>
+            )}
+          </section>
+        )}
       </Page>
     </>
   );
 }
 
 function Page({ children }) {
-  return <main className="max-w-3xl mx-auto p-4">{children}</main>;
+  return <main className="mx-auto max-w-3xl p-4 sm:p-6">{children}</main>;
 }
+
 function Alert({ children }) {
-  return <div className="p-3 rounded bg-gray-100 border">{children}</div>;
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 text-sm font-semibold text-gray-700">
+      {children}
+    </div>
+  );
+}
+
+function Badge({ children, intent = "neutral" }) {
+  const styles =
+    intent === "warning"
+      ? "bg-gradient-to-r from-red-50 to-rose-50 text-red-700 border-red-200"
+      : "bg-gradient-to-r from-slate-100 to-slate-200 text-slate-700 border-slate-300";
+  return (
+    <span
+      className={`inline-block rounded-full border px-3 py-1.5 text-xs font-black ${styles}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+function Field({ label, required = false, children }) {
+  return (
+    <label className="flex w-full flex-col gap-1 text-sm font-semibold text-gray-700">
+      <span>
+        {label}
+        {required ? (
+          <span className="ml-1 font-normal text-red-500">*</span>
+        ) : null}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function DetailRow({ icon, children }) {
+  const Icon = icon;
+  return (
+    <p className="flex items-start gap-2 text-sm font-medium text-gray-700">
+      <Icon className="mt-0.5 h-4 w-4 text-gray-400" />
+      <span>{children}</span>
+    </p>
+  );
 }

--- a/src/utils/react-query-shim.js
+++ b/src/utils/react-query-shim.js
@@ -1,0 +1,232 @@
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+const INVALIDATE = Symbol("invalidate");
+
+const hashKey = (key) => {
+  if (Array.isArray(key)) return JSON.stringify(key);
+  if (typeof key === "string") return key;
+  return JSON.stringify(key || []);
+};
+
+class QueryClient {
+  constructor() {
+    this.cache = new Map();
+    this.subscribers = new Map();
+  }
+
+  getQueryData(queryKey) {
+    return this.cache.get(hashKey(queryKey));
+  }
+
+  setQueryData(queryKey, updater) {
+    const key = hashKey(queryKey);
+    const previous = this.cache.get(key);
+    const value =
+      typeof updater === "function" ? updater(previous) : updater;
+    this.cache.set(key, value);
+    this.#notify(key, value);
+    return value;
+  }
+
+  invalidateQueries({ queryKey }) {
+    const key = hashKey(queryKey);
+    this.cache.delete(key);
+    this.#notify(key, INVALIDATE);
+  }
+
+  subscribe(queryKey, listener) {
+    const key = hashKey(queryKey);
+    const listeners = this.subscribers.get(key) || new Set();
+    listeners.add(listener);
+    this.subscribers.set(key, listeners);
+    return () => {
+      const current = this.subscribers.get(key);
+      if (!current) return;
+      current.delete(listener);
+      if (!current.size) {
+        this.subscribers.delete(key);
+      }
+    };
+  }
+
+  #notify(key, value) {
+    const listeners = this.subscribers.get(key);
+    if (!listeners || !listeners.size) return;
+    listeners.forEach((listener) => {
+      try {
+        listener(value);
+      } catch (error) {
+        console.error("Query listener error", error);
+      }
+    });
+  }
+}
+
+const QueryClientContext = createContext(null);
+
+const QueryClientProvider = ({ client, children }) => {
+  if (!client) {
+    throw new Error("QueryClientProvider requires a client instance");
+  }
+  const value = useMemo(() => client, [client]);
+  return createElement(QueryClientContext.Provider, { value }, children);
+};
+
+const useQueryClient = () => {
+  const client = useContext(QueryClientContext);
+  if (!client) {
+    throw new Error("useQueryClient must be used within a QueryClientProvider");
+  }
+  return client;
+};
+
+const useQuery = ({ queryKey, queryFn, enabled = true, retry = false }) => {
+  const client = useQueryClient();
+  const key = useMemo(() => hashKey(queryKey), [queryKey]);
+  const queryFnRef = useRef(queryFn);
+  queryFnRef.current = queryFn;
+
+  const getInitialState = useCallback(() => {
+    const cached = client.getQueryData(queryKey);
+    if (cached !== undefined) {
+      return { status: "success", data: cached, error: null };
+    }
+    return {
+      status: enabled ? "loading" : "idle",
+      data: cached,
+      error: null,
+    };
+  }, [client, queryKey, enabled]);
+
+  const [state, setState] = useState(getInitialState);
+
+  useEffect(() => {
+    setState(getInitialState());
+  }, [getInitialState, key]);
+
+  const execute = useCallback(async () => {
+    if (!enabled || typeof queryFnRef.current !== "function") return undefined;
+    setState((prev) => ({ ...prev, status: "loading", error: null }));
+    let attempts = 0;
+    const run = async () => {
+      attempts += 1;
+      try {
+        const result = await queryFnRef.current();
+        client.setQueryData(queryKey, result);
+        setState({ status: "success", data: result, error: null });
+        return result;
+      } catch (error) {
+        if (retry && attempts <= 3) {
+          return run();
+        }
+        setState({ status: "error", data: undefined, error });
+        throw error;
+      }
+    };
+    return run();
+  }, [client, queryKey, enabled, retry]);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    let cancelled = false;
+    if (state.status === "loading" || state.status === "idle") {
+      execute().catch(() => {
+        /* handled in state */
+      });
+    }
+    const unsubscribe = client.subscribe(queryKey, (value) => {
+      if (cancelled) return;
+      if (value === INVALIDATE) {
+        execute().catch(() => {
+          /* handled */
+        });
+        return;
+      }
+      setState({ status: "success", data: value, error: null });
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [client, execute, key, queryKey, enabled, state.status]);
+
+  const refetch = useCallback(() => execute(), [execute]);
+
+  return {
+    data: state.data,
+    error: state.error,
+    status: state.status,
+    isLoading: state.status === "loading",
+    isError: state.status === "error",
+    isSuccess: state.status === "success",
+    refetch,
+  };
+};
+
+const useMutation = ({ mutationFn, onSuccess, onError, onSettled } = {}) => {
+  const [status, setStatus] = useState("idle");
+  const [error, setError] = useState(null);
+
+  const mutateAsync = useCallback(
+    async (variables) => {
+      if (typeof mutationFn !== "function") {
+        throw new Error("mutationFn must be a function");
+      }
+      setStatus("pending");
+      setError(null);
+      try {
+        const result = await mutationFn(variables);
+        setStatus("success");
+        onSuccess?.(result, variables, undefined);
+        onSettled?.(result, null, variables, undefined);
+        return result;
+      } catch (err) {
+        setStatus("error");
+        setError(err);
+        onError?.(err, variables, undefined);
+        onSettled?.(undefined, err, variables, undefined);
+        throw err;
+      }
+    },
+    [mutationFn, onError, onSettled, onSuccess],
+  );
+
+  const mutate = useCallback(
+    (variables) => {
+      mutateAsync(variables).catch(() => {
+        /* error already stored */
+      });
+    },
+    [mutateAsync],
+  );
+
+  return {
+    mutate,
+    mutateAsync,
+    status,
+    error,
+    isPending: status === "pending",
+    isError: status === "error",
+    isSuccess: status === "success",
+  };
+};
+
+const createQueryClient = () => new QueryClient();
+
+export {
+  QueryClient,
+  QueryClientProvider,
+  createQueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient,
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,22 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 // https://vite.dev/config/
 export default defineConfig({
   // Ensure correct asset paths for GitHub Pages
   base: '/ttp-play-dates/',
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@tanstack/react-query': resolve(
+        __dirname,
+        'src/utils/react-query-shim.js',
+      ),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add an organizer-only edit mode to the match details page with validation, participant management, and share/invite actions
- introduce a lightweight react-query-compatible client and register it at the app root for async match updates
- configure Vite to resolve the react-query shim

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e53be084f8832893da52bfbc6219ac