### PR TITLE
Improve private match editing flow

### DIFF
--- a/src/TennisMatchApp.jsx
+++ b/src/TennisMatchApp.jsx
@@ -694,6 +694,14 @@ const TennisMatchApp = () => {
     setMatchDetailsOrigin("browse");
   }, [goToBrowse, goToInvites, matchDetailsOrigin]);
 
+  const handleManageInvitesFromDetails = useCallback(
+    (matchId) => {
+      if (!matchId) return;
+      openInviteScreen(matchId, { onClose: closeMatchDetailsModal });
+    },
+    [closeMatchDetailsModal, openInviteScreen],
+  );
+
   const openInviteScreen = useCallback(
     async (matchId, { skipNavigation = false, onClose } = {}) => {
       const numericMatchId = Number(matchId);
@@ -4667,6 +4675,7 @@ const TennisMatchApp = () => {
         onUpdateMatch={setViewMatch}
         onToast={displayToast}
         formatDateTime={formatDateTime}
+        onManageInvites={handleManageInvitesFromDetails}
       />
       {Toast()}
       <ProfileManager

--- a/src/pages/MatchPage.jsx
+++ b/src/pages/MatchPage.jsx
@@ -38,6 +38,7 @@ import {
   ensureOptionPresent,
   isValidOptionValue,
 } from "../utils/matchOptions";
+import { isPrivateMatch } from "../utils/matchPrivacy";
 import { buildMatchUpdatePayload } from "../utils/matchPayload";
 
 const DEFAULT_FORM = {
@@ -94,6 +95,7 @@ const buildInitialForm = (match) => {
     parseCoordinate(match.latitude) ?? parseCoordinate(match.lat);
   const longitude =
     parseCoordinate(match.longitude) ?? parseCoordinate(match.lng);
+  const privateMatch = isPrivateMatch(match);
   return {
     date: toDateInput(match.start_date_time),
     time: toTimeInput(match.start_date_time),
@@ -101,7 +103,9 @@ const buildInitialForm = (match) => {
     latitude,
     longitude,
     matchFormat: match.match_format || match.format || "",
-    level: match.skill_level || match.skill_level_min || "",
+    level: privateMatch
+      ? ""
+      : match.skill_level || match.skill_level_min || "",
     notes: match.notes || "",
   };
 };
@@ -175,7 +179,7 @@ export default function MatchPage() {
 
   const archived = match?.status === "archived";
   const cancelled = match?.status === "cancelled";
-  const isPrivate = match?.privacy === "private";
+  const isPrivate = isPrivateMatch(match);
   const isOpenMatch = Boolean(match) && !isPrivate;
   const isHost = Boolean(match?.host_id) && idsMatch(currentUser?.id, match.host_id);
   const canEdit = isHost && !archived && !cancelled;

--- a/src/utils/matchPrivacy.js
+++ b/src/utils/matchPrivacy.js
@@ -1,0 +1,41 @@
+const normalizePrivacyValue = (value) => {
+  if (typeof value !== "string") return "";
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return "";
+  if (normalized === "private" || normalized === "closed") {
+    return "private";
+  }
+  if (normalized === "open" || normalized === "public") {
+    return "open";
+  }
+  return normalized;
+};
+
+const getMatchPrivacy = (match) => {
+  if (!match || typeof match !== "object") {
+    return "open";
+  }
+
+  const candidates = [
+    match.privacy,
+    match.privacy_status,
+    match.match_type,
+    match.matchType,
+    match.type,
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizePrivacyValue(candidate);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return "open";
+};
+
+const isPrivateMatch = (match) => getMatchPrivacy(match) === "private";
+
+const isOpenMatch = (match) => getMatchPrivacy(match) !== "private";
+
+export { getMatchPrivacy, isOpenMatch, isPrivateMatch };


### PR DESCRIPTION
## Summary
- normalize match privacy detection so private matches skip level metadata when editing
- add a private-match invite manager entry point in the match details modal
- reuse the privacy helper on the match page to align edit forms with the new behavior

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e59f8ee4fc83288519d4b409669de0