### PR TITLE
Handle private match cancellation gracefully

### DIFF
--- a/src/services/matches.js
+++ b/src/services/matches.js
@@ -256,12 +256,27 @@ export const updateMatch = (id, updates) =>
     })
   );
 
-export const cancelMatch = (id) =>
-  unwrap(
+export const cancelMatch = async (id) => {
+  try {
+    return await unwrap(
+      api(`/matches/${id}/cancel`, {
+        method: "POST",
+        json: { match_id: id },
+      }),
+    );
+  } catch (error) {
+    const status = Number(error?.status ?? error?.response?.status);
+    if (status && ![404, 405].includes(status)) {
+      throw error;
+    }
+  }
+
+  return unwrap(
     api(`/matches/${id}`, {
       method: "DELETE",
     })
   );
+};
 
 export const joinMatch = (id) =>
   unwrap(


### PR DESCRIPTION
## Summary
- call the dedicated cancel endpoint before falling back to deleting a match so private events cancel correctly

## Testing
- npm run lint *(fails: requires the optional `globals` package in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e48736ac483268b83f4ded6f78d43)