### PR TITLE
Add alternate date/time options for private matches

### DIFF
--- a/src/TennisMatchApp.jsx
+++ b/src/TennisMatchApp.jsx
@@ -745,6 +745,7 @@ const TennisMatchApp = () => {
     skillLevel: null,
     format: "Doubles",
     dateTime: "",
+    availabilityOptions: [],
     location: "",
     latitude: null,
     longitude: null,
@@ -2722,6 +2723,24 @@ const TennisMatchApp = () => {
       hour: "numeric",
       minute: "2-digit",
     });
+  };
+
+  const formatAlternateTimes = (options) => {
+    if (!Array.isArray(options)) return [];
+    const formatted = [];
+    options.forEach((option) => {
+      if (!option) return;
+      const parsed = new Date(option);
+      if (Number.isNaN(parsed.getTime())) return;
+      formatted.push(formatDateTime(parsed));
+    });
+    return formatted;
+  };
+
+  const buildAlternateTimesNote = (options) => {
+    const formatted = formatAlternateTimes(options);
+    if (formatted.length === 0) return "";
+    return `Alternate options:\n- ${formatted.join("\n- ")}`;
   };
 
   const formatHoursUntilStart = useCallback((hours) => {
@@ -4811,6 +4830,8 @@ const TennisMatchApp = () => {
 
   const CreateMatchScreen = () => {
     const [recentLocations, setRecentLocations] = useState(() => loadStoredLocations());
+    const [alternateDateTime, setAlternateDateTime] = useState("");
+    const [alternateError, setAlternateError] = useState("");
 
     useEffect(() => {
       const syncRecentLocations = () => {
@@ -4896,6 +4917,15 @@ const TennisMatchApp = () => {
         }
       }
 
+      const alternateTimesNote =
+        matchData.type === "closed"
+          ? buildAlternateTimesNote(matchData.availabilityOptions)
+          : "";
+      const combinedNotes = [matchData.notes, alternateTimesNote]
+        .map((entry) => entry?.trim())
+        .filter(Boolean)
+        .join("\n\n");
+
       const privacy = matchData.type === "closed" ? "private" : "open";
       const skillLevelValue =
         matchData.type === "closed"
@@ -4917,7 +4947,7 @@ const TennisMatchApp = () => {
         skillLevel: skillLevelValue,
         match_format: matchData.format || undefined,
         format: matchData.format || undefined,
-        notes: matchData.notes || undefined,
+        notes: combinedNotes || undefined,
       };
 
       return Object.fromEntries(
@@ -4996,6 +5026,20 @@ const TennisMatchApp = () => {
                     <p className="font-black text-gray-900 text-lg">
                       {formatDateTime(matchData.dateTime)}
                     </p>
+                    {matchData.availabilityOptions.length > 0 && (
+                      <div className="mt-2 space-y-1">
+                        <p className="text-xs font-black text-gray-500 uppercase tracking-wider">
+                          Alternate Options
+                        </p>
+                        <ul className="list-disc list-inside text-sm font-semibold text-gray-600">
+                          {formatAlternateTimes(
+                            matchData.availabilityOptions
+                          ).map((option, index) => (
+                            <li key={`${option}-${index}`}>{option}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
                   </div>
                 </div>
 
@@ -5168,6 +5212,8 @@ const TennisMatchApp = () => {
                         setMatchData((prev) => ({
                           ...prev,
                           type: type.id,
+                          availabilityOptions:
+                            type.id === "closed" ? prev.availabilityOptions : [],
                           skillLevel:
                             type.id === "closed" ? DEFAULT_SKILL_LEVEL : null,
                         }))
@@ -5205,6 +5251,105 @@ const TennisMatchApp = () => {
                   }
                   className="w-full px-4 py-3.5 border-2 border-gray-200 rounded-xl focus:ring-2 focus:ring-green-500 focus:border-green-500 transition-colors font-bold text-gray-800"
                 />
+                {matchData.type === "closed" && (
+                  <div className="mt-4">
+                    <div className="flex items-center justify-between mb-3">
+                      <label className="text-xs font-black text-gray-600 uppercase tracking-wider">
+                        Alternate Options (up to 5)
+                      </label>
+                      <span className="text-xs font-semibold text-gray-400">
+                        Optional
+                      </span>
+                    </div>
+                    <div className="flex flex-col sm:flex-row gap-3">
+                      <input
+                        type="datetime-local"
+                        value={alternateDateTime}
+                        onChange={(e) => {
+                          setAlternateDateTime(e.target.value);
+                          if (alternateError) setAlternateError("");
+                        }}
+                        className="flex-1 px-4 py-3 border-2 border-gray-200 rounded-xl focus:ring-2 focus:ring-green-500 focus:border-green-500 transition-colors font-semibold text-gray-800"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setAlternateError("");
+                          if (!alternateDateTime) {
+                            setAlternateError("Pick a date/time to add.");
+                            return;
+                          }
+                          if (alternateDateTime === matchData.dateTime) {
+                            setAlternateError(
+                              "That matches your main date/time."
+                            );
+                            return;
+                          }
+                          if (
+                            matchData.availabilityOptions.includes(
+                              alternateDateTime
+                            )
+                          ) {
+                            setAlternateError("That option is already added.");
+                            return;
+                          }
+                          if (matchData.availabilityOptions.length >= 5) {
+                            setAlternateError(
+                              "You can add up to 5 alternate options."
+                            );
+                            return;
+                          }
+                          setMatchData((prev) => ({
+                            ...prev,
+                            availabilityOptions: [
+                              ...prev.availabilityOptions,
+                              alternateDateTime,
+                            ],
+                          }));
+                          setAlternateDateTime("");
+                        }}
+                        className="px-5 py-3 bg-white border-2 border-gray-200 text-gray-700 rounded-xl font-black hover:bg-gray-50 transition-colors"
+                      >
+                        Add Option
+                      </button>
+                    </div>
+                    {alternateError && (
+                      <p className="text-xs font-semibold text-red-500 mt-2">
+                        {alternateError}
+                      </p>
+                    )}
+                    {matchData.availabilityOptions.length > 0 && (
+                      <div className="mt-3 space-y-2">
+                        {matchData.availabilityOptions.map((option, index) => {
+                          const formatted = formatAlternateTimes([option])[0];
+                          if (!formatted) return null;
+                          return (
+                            <div
+                              key={`${option}-${index}`}
+                              className="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-700"
+                            >
+                              <span>{formatted}</span>
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  setMatchData((prev) => ({
+                                    ...prev,
+                                    availabilityOptions: prev.availabilityOptions.filter(
+                                      (_, idx) => idx !== index
+                                    ),
+                                  }))
+                                }
+                                className="text-xs font-black text-gray-500 hover:text-red-500 transition-colors"
+                              >
+                                Remove
+                              </button>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
 
               <div>
@@ -5700,6 +5845,10 @@ const TennisMatchApp = () => {
       parts.push("You're invited to a tennis match!");
       if (host) parts.push(`Host: ${host}`);
       if (matchData.dateTime) parts.push(`When: ${formatDateTime(matchData.dateTime)}`);
+      const alternateTimes = formatAlternateTimes(matchData.availabilityOptions);
+      if (alternateTimes.length > 0) {
+        parts.push(`Other options: ${alternateTimes.join("; ")}`);
+      }
       if (matchData.location) parts.push(`Where: ${matchData.location}`);
       if (matchData.format) parts.push(`Format: ${matchData.format}`);
       if (matchData.skillLevel && matchData.skillLevel !== "Any Level") {

--- a/src/components/MatchCreatorFlow.jsx
+++ b/src/components/MatchCreatorFlow.jsx
@@ -86,6 +86,7 @@ const initialMatchData = () => {
     skillLevel: "4.0",
     format: "Doubles",
     notes: "",
+    alternateTimes: [],
     invitedPlayers: [],
     manualInvitees: [],
     listingVisibility: "listed",
@@ -149,6 +150,22 @@ const formatDateDisplay = (dateStr) => {
     month: "short",
     day: "numeric",
   });
+};
+
+const formatAlternateSlotDisplay = (slot) => {
+  if (!slot?.date || !slot?.startTime) return "";
+  return `${formatDateDisplay(slot.date)} at ${formatTimeDisplay(slot.startTime)}`;
+};
+
+const formatAlternateSlots = (slots) =>
+  (Array.isArray(slots) ? slots : [])
+    .map((slot) => formatAlternateSlotDisplay(slot))
+    .filter(Boolean);
+
+const buildAlternateTimesNote = (slots) => {
+  const formatted = formatAlternateSlots(slots);
+  if (formatted.length === 0) return "";
+  return `Alternate options:\n- ${formatted.join("\n- ")}`;
 };
 
 const formatRelativeDate = (isoValue) => {
@@ -265,6 +282,9 @@ const MatchCreatorFlow = ({ onCancel, onReturnHome, onMatchCreated, currentUser 
   const [contactName, setContactName] = useState("");
   const [contactPhone, setContactPhone] = useState("");
   const [contactError, setContactError] = useState("");
+  const [alternateDate, setAlternateDate] = useState("");
+  const [alternateTime, setAlternateTime] = useState("");
+  const [alternateError, setAlternateError] = useState("");
   const [isFormatManuallySelected, setIsFormatManuallySelected] = useState(false);
   const [recentLocations, setRecentLocations] = useState(() => loadStoredLocations());
   const [recentPlayers, setRecentPlayers] = useState(() => loadStoredRecentPlayers());
@@ -337,6 +357,9 @@ const MatchCreatorFlow = ({ onCancel, onReturnHome, onMatchCreated, currentUser 
     setContactName("");
     setContactPhone("");
     setContactError("");
+    setAlternateDate("");
+    setAlternateTime("");
+    setAlternateError("");
     setIsFormatManuallySelected(false);
   }, []);
 
@@ -415,6 +438,50 @@ const MatchCreatorFlow = ({ onCancel, onReturnHome, onMatchCreated, currentUser 
     },
     [setMatchData],
   );
+
+  const handleAlternateTimeChange = useCallback((value) => {
+    setAlternateTime(value ? clampTimeToRange(value) : "");
+  }, []);
+
+  const handleAddAlternateSlot = useCallback(() => {
+    setAlternateError("");
+    if (!alternateDate || !alternateTime) {
+      setAlternateError("Add a date and time for this option.");
+      return;
+    }
+    const normalizedTime = clampTimeToRange(alternateTime);
+    const optionIso = combineDateAndTimeToIso(alternateDate, normalizedTime);
+    if (!optionIso) {
+      setAlternateError("That option time isn't valid.");
+      return;
+    }
+    const mainIso = combineDateAndTimeToIso(matchData.date, matchData.startTime);
+    if (mainIso && optionIso === mainIso) {
+      setAlternateError("That matches your main date/time.");
+      return;
+    }
+    const existingIso = (matchData.alternateTimes || []).some((slot) => {
+      const slotIso = combineDateAndTimeToIso(slot.date, slot.startTime);
+      return slotIso && slotIso === optionIso;
+    });
+    if (existingIso) {
+      setAlternateError("That option is already added.");
+      return;
+    }
+    if ((matchData.alternateTimes || []).length >= 5) {
+      setAlternateError("You can add up to 5 alternate options.");
+      return;
+    }
+    setMatchData((prev) => ({
+      ...prev,
+      alternateTimes: [
+        ...(prev.alternateTimes || []),
+        { date: alternateDate, startTime: normalizedTime },
+      ],
+    }));
+    setAlternateDate("");
+    setAlternateTime("");
+  }, [alternateDate, alternateTime, matchData, setMatchData]);
 
   const recordRecentLocation = useCallback(
     (locationLabel, latitude, longitude) => {
@@ -520,6 +587,15 @@ const MatchCreatorFlow = ({ onCancel, onReturnHome, onMatchCreated, currentUser 
       return;
     }
 
+    const alternateTimesNote =
+      matchData.type === "private"
+        ? buildAlternateTimesNote(matchData.alternateTimes)
+        : "";
+    const combinedNotes = [matchData.notes, alternateTimesNote]
+      .map((entry) => entry?.trim())
+      .filter(Boolean)
+      .join("\n\n");
+
     const payload = {
       status: "upcoming",
       match_type: matchData.type === "private" ? "private" : "open",
@@ -529,7 +605,7 @@ const MatchCreatorFlow = ({ onCancel, onReturnHome, onMatchCreated, currentUser 
       longitude: matchData.longitude ?? undefined,
       player_limit: matchData.totalPlayers,
       match_format: matchData.format,
-      notes: matchData.notes || undefined,
+      notes: combinedNotes || undefined,
     };
 
     if (matchData.type === "open" && matchData.skillLevel) {
@@ -664,11 +740,21 @@ const MatchCreatorFlow = ({ onCancel, onReturnHome, onMatchCreated, currentUser 
   };
 
   const buildShareMessage = useCallback(
-    () =>
-      `Join my ${matchData.format} match on ${formatDateDisplay(matchData.date)} at ${formatTimeDisplay(
-        matchData.startTime,
-      )} at ${matchData.location}.`,
-    [matchData.format, matchData.date, matchData.startTime, matchData.location]
+    () => {
+      const primary = `Join my ${matchData.format} match on ${formatDateDisplay(
+        matchData.date,
+      )} at ${formatTimeDisplay(matchData.startTime)} at ${matchData.location}.`;
+      const alternateOptions = formatAlternateSlots(matchData.alternateTimes);
+      if (alternateOptions.length === 0) return primary;
+      return `${primary} Other options: ${alternateOptions.join("; ")}.`;
+    },
+    [
+      matchData.format,
+      matchData.date,
+      matchData.startTime,
+      matchData.location,
+      matchData.alternateTimes,
+    ]
   );
 
   const handleShare = (method) => {
@@ -719,7 +805,12 @@ const MatchCreatorFlow = ({ onCancel, onReturnHome, onMatchCreated, currentUser 
     if (matchData.type === "open" && matchData.skillLevel) {
       description += ` Skill level: NTRP ${matchData.skillLevel}.`;
     }
-    if (matchData.notes) description += ` ${matchData.notes}`;
+    const alternateTimesNote = buildAlternateTimesNote(matchData.alternateTimes);
+    const combinedNotes = [matchData.notes, alternateTimesNote]
+      .map((entry) => entry?.trim())
+      .filter(Boolean)
+      .join("\n\n");
+    if (combinedNotes) description += ` ${combinedNotes}`;
 
     const details = {
       title,
@@ -827,7 +918,13 @@ const MatchCreatorFlow = ({ onCancel, onReturnHome, onMatchCreated, currentUser 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <button
                 onClick={() =>
-                  setMatchData((prev) => ({ ...prev, type: "open", invitedPlayers: [] }))
+                  setMatchData((prev) => ({
+                    ...prev,
+                    type: "open",
+                    invitedPlayers: [],
+                    manualInvitees: [],
+                    alternateTimes: [],
+                  }))
                 }
                 className={`p-6 rounded-2xl border-2 transition-all ${
                   matchData.type === "open"
@@ -948,6 +1045,96 @@ const MatchCreatorFlow = ({ onCancel, onReturnHome, onMatchCreated, currentUser 
                 </div>
               </div>
             </div>
+            {matchData.type === "private" && (
+              <div className="mt-4 border border-gray-200 rounded-xl p-4 space-y-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h4 className="text-sm font-semibold text-gray-700">
+                      Alternate Options
+                    </h4>
+                    <p className="text-xs text-gray-500">
+                      Add up to 5 backup dates/times for invitees.
+                    </p>
+                  </div>
+                  <span className="text-xs font-semibold text-gray-400">Optional</span>
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                  <div>
+                    <label className="block text-xs font-medium text-gray-500 mb-2">
+                      DATE
+                    </label>
+                    <input
+                      type="date"
+                      value={alternateDate}
+                      onChange={(e) => {
+                        setAlternateDate(e.target.value);
+                        if (alternateError) setAlternateError("");
+                      }}
+                      className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-500 mb-2">
+                      TIME
+                    </label>
+                    <input
+                      type="time"
+                      min={MIN_START_TIME}
+                      max={MAX_START_TIME}
+                      value={alternateTime}
+                      onChange={(e) => {
+                        handleAlternateTimeChange(e.target.value);
+                        if (alternateError) setAlternateError("");
+                      }}
+                      onBlur={(e) => handleAlternateTimeChange(e.target.value)}
+                      className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                    />
+                  </div>
+                  <div className="flex items-end">
+                    <button
+                      type="button"
+                      onClick={handleAddAlternateSlot}
+                      className="w-full px-4 py-3 bg-white border border-gray-300 rounded-lg text-sm font-semibold text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      Add option
+                    </button>
+                  </div>
+                </div>
+                {alternateError && (
+                  <p className="text-xs font-semibold text-red-600">{alternateError}</p>
+                )}
+                {matchData.alternateTimes?.length > 0 && (
+                  <div className="space-y-2">
+                    {matchData.alternateTimes.map((slot, index) => {
+                      const formatted = formatAlternateSlotDisplay(slot);
+                      if (!formatted) return null;
+                      return (
+                        <div
+                          key={`${slot.date}-${slot.startTime}-${index}`}
+                          className="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-700"
+                        >
+                          <span>{formatted}</span>
+                          <button
+                            type="button"
+                            onClick={() =>
+                              setMatchData((prev) => ({
+                                ...prev,
+                                alternateTimes: (prev.alternateTimes || []).filter(
+                                  (_, idx) => idx !== index
+                                ),
+                              }))
+                            }
+                            className="text-xs font-semibold text-gray-500 hover:text-red-500 transition-colors"
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            )}
           </div>
           <div>
             <h3 className="text-sm font-semibold text-gray-600 uppercase tracking-wider mb-4">
@@ -1579,6 +1766,21 @@ const MatchCreatorFlow = ({ onCancel, onReturnHome, onMatchCreated, currentUser 
                   {formatDateDisplay(matchData.date)}, {formatTimeDisplay(matchData.startTime)}
                 </span>
               </div>
+              {matchData.alternateTimes?.length > 0 && (
+                <div className="flex items-start gap-3">
+                  <Clock size={16} className="text-gray-500 mt-1" />
+                  <div className="text-gray-700">
+                    <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                      Alternate Options
+                    </div>
+                    <ul className="list-disc list-inside text-sm">
+                      {formatAlternateSlots(matchData.alternateTimes).map((option, index) => (
+                        <li key={`${option}-${index}`}>{option}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              )}
               <div className="flex items-center gap-3">
                 <MapPin size={16} className="text-gray-500" />
                 <span className="text-gray-700">{matchData.location}</span>


### PR DESCRIPTION
### Motivation
- Improve private match invitations by allowing hosts to offer multiple date/time options so invitees have flexible choices and higher chance to join.

### Description
- Added alternate/availability option support to the main in-app create flow by introducing `availabilityOptions` on `matchData`, UI for adding/removing datetime-local options, client-side validation (no duplicates, not equal to primary time, max 5), and formatted display in the preview and invite screens (`src/TennisMatchApp.jsx`).
- Implemented the same feature in the dedicated match creator flow with `alternateTimes` state, date/time inputs, add/remove UI, validation, formatted review list, and sharing text updates (`src/components/MatchCreatorFlow.jsx`).
- Added helper functions to format alternate times and to build a combined notes payload (`buildAlternateTimesNote`, `formatAlternateTimes`, `formatAlternateSlots`) and included alternate options in `notes` sent to the API and in calendar/event descriptions and share messages.
- Ensured switching match types clears or preserves alternate options appropriately and surfaced alternate options in share messages and previews so invitees can see backup slots.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite served the app at `/ttp-play-dates/` (server ready). (succeeded)
- Ran a headless Playwright script that opened the create flow as an authenticated host, selected a private match, filled a primary date/time, added an alternate date/time option, clicked Add, and captured a screenshot of the alternate options UI; the script completed and produced `artifacts/alternate-options.png`. (succeeded)
- No unit tests or lint runs were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6983610df7d48326861e753be9ec32a5)