### PR TITLE
Raise private invite and player limit to 30

### DIFF
--- a/src/components/MatchCreatorFlow.jsx
+++ b/src/components/MatchCreatorFlow.jsx
@@ -53,7 +53,7 @@ import {
 } from "../utils/recentPlayers";
 
 const HOURS_IN_MS = 60 * 60 * 1000;
-const MAX_PRIVATE_INVITES = 12;
+const MAX_PRIVATE_INVITES = 30;
 
 const pad = (value) => String(value).padStart(2, "0");
 
@@ -1060,10 +1060,10 @@ const MatchCreatorFlow = ({ onCancel, onReturnHome, onMatchCreated, currentUser 
                 onClick={() =>
                   setMatchData((prev) => ({
                     ...prev,
-                    totalPlayers: Math.min(12, prev.totalPlayers + 1),
+                    totalPlayers: Math.min(30, prev.totalPlayers + 1),
                   }))
                 }
-                disabled={matchData.totalPlayers >= 12}
+                disabled={matchData.totalPlayers >= 30}
                 className="w-14 h-14 rounded-full border-2 border-gray-300 hover:border-gray-400 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center text-xl font-semibold text-gray-600 transition-colors"
               >
                 +

--- a/src/utils/matchPayload.js
+++ b/src/utils/matchPayload.js
@@ -2,7 +2,7 @@ const isFiniteNumber = (value) =>
   typeof value === "number" && Number.isFinite(value);
 
 const PLAYER_LIMIT_MIN = 2;
-const PLAYER_LIMIT_MAX = 12;
+const PLAYER_LIMIT_MAX = 30;
 
 const parsePlayerLimit = (value) => {
   if (value === undefined || value === null) return null;


### PR DESCRIPTION
### Motivation
- Increase the maximum allowed private invites and total players in the match creator from 12 to 30 to support larger matches.

### Description
- Update `MAX_PRIVATE_INVITES` in `src/components/MatchCreatorFlow.jsx` and the UI controls that clamp `totalPlayers` to use `30` instead of `12`.
- Update `PLAYER_LIMIT_MAX` in `src/utils/matchPayload.js` to `30` so payload parsing/validation aligns with the new UI cap.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6988a67e27fc832682a66fc3f5f1c1d7)